### PR TITLE
Create support for --drall-group option

### DIFF
--- a/.docker/main/drush/sites/donnie.site.yml
+++ b/.docker/main/drush/sites/donnie.site.yml
@@ -3,3 +3,6 @@ local:
   uri: http://donnie.drall.local
   paths:
     files: sites/donnie/files
+  drall:
+    groups:
+      - bluish

--- a/.docker/main/drush/sites/leo.site.yml
+++ b/.docker/main/drush/sites/leo.site.yml
@@ -3,3 +3,6 @@ local:
   uri: http://leo.drall.local
   paths:
     files: sites/leo/files
+  drall:
+    groups:
+      - bluish

--- a/.docker/main/drush/sites/mikey.site.yml
+++ b/.docker/main/drush/sites/mikey.site.yml
@@ -3,3 +3,6 @@ local:
   uri: http://mikey.drall.local
   paths:
     files: sites/mikey/files
+  drall:
+    groups:
+      - reddish

--- a/.docker/main/drush/sites/ralph.site.yml
+++ b/.docker/main/drush/sites/ralph.site.yml
@@ -3,3 +3,6 @@ local:
   uri: http://ralph.drall.local
   paths:
     files: sites/ralph/files
+  drall:
+    groups:
+      - reddish

--- a/.docker/main/sites.bluish.php
+++ b/.docker/main/sites.bluish.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * @file
+ * Site group containing ninja turtles with a bluish bandana.
+ */
+
+$sites['donnie.drall.local'] = 'donnie';
+$sites['leo.drall.local'] = 'leo';

--- a/.docker/main/sites.reddish.php
+++ b/.docker/main/sites.reddish.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * @file
+ * Site group containing ninja turtles with a reddish bandana.
+ */
+
+$sites['mikey.drall.local'] = 'mikey';
+$sites['ralph.drall.local'] = 'ralph';

--- a/README.md
+++ b/README.md
@@ -84,6 +84,49 @@ drush @ralph.local st --fields=site
 Here, `@@site` is replaced with site names detected from various site alias
 definitions.
 
+## Site groups
+
+Drall allows you to group your sites so that you can run commands on such
+groups with ease.
+
+```
+drall exec --drall-group=GROUP core:rebuild
+```
+
+Here's how you can create site groups.
+
+### With site aliases
+
+In a site alias definition file, you can assign site aliases to one or more
+groups like this:
+
+```yaml
+# File: tnmt.site.yml
+local:
+  root: /opt/drupal/web
+  uri: http://tmnt.com/
+  # ...
+  drall:
+    groups:
+      - cartoon
+      - action
+```
+
+This puts the alias `@tnmt.local` in the `cartoon` and `action` groups.
+
+### With sites.php
+
+If your project doesn't use site aliases, you can still group your sites using
+one or more `sites.GROUP.php` files like this:
+
+```php
+# File: sites.bluish.php
+$sites['donnie.drall.local'] = 'donnie';
+$sites['leo.drall.local'] = 'leo';
+```
+
+This puts the sites `donnie` and `leo` in a group named `bluish`.
+
 ## Development
 
 Here's how you can set up a local dev environment.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     volumes:
       - .:/opt/drall
       - .docker/main/sites.php:/opt/drupal/web/sites/sites.php
+      - .docker/main/sites.reddish.php:/opt/drupal/web/sites/sites.reddish.php
+      - .docker/main/sites.bluish.php:/opt/drupal/web/sites/sites.bluish.php
       - .docker/main/composer.json:/opt/drupal/composer.json
       - .docker/main/composer.lock:/opt/drupal/composer.lock
       - .docker/main/drush:/opt/drupal/drush

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -29,4 +29,7 @@
     <rule ref="Drupal.Files.LineLength.TooLong">
         <severity>0</severity>
     </rule>
+    <rule ref="Drupal.NamingConventions.ValidFunctionName.ScopeNotCamelCaps">
+        <severity>0</severity>
+    </rule>
 </ruleset>

--- a/src/Commands/ExecCommand.php
+++ b/src/Commands/ExecCommand.php
@@ -28,7 +28,6 @@ class ExecCommand extends BaseCommand {
       NULL,
       InputOption::VALUE_REQUIRED,
       'Site group identifier.'
-
     );
 
     $this->addUsage('core:status');

--- a/src/Commands/ExecCommand.php
+++ b/src/Commands/ExecCommand.php
@@ -31,6 +31,10 @@ class ExecCommand extends BaseCommand {
     );
 
     $this->addUsage('core:status');
+    $this->addUsage('--uri=@@uri core:status');
+    $this->addUsage('@@site.ENV core:status');
+    $this->addUsage('--drall-group=GROUP core:status');
+
     $this->ignoreValidationErrors();
   }
 

--- a/src/Commands/SiteAliasesCommand.php
+++ b/src/Commands/SiteAliasesCommand.php
@@ -15,12 +15,16 @@ class SiteAliasesCommand extends BaseCommand {
     $this->setName('site:aliases');
     $this->setAliases(['sa']);
     $this->setDescription('Get a list of site aliases.');
+
     $this->addOption(
       'drall-group',
       NULL,
       InputOption::VALUE_REQUIRED,
       'Site group identifier.'
     );
+
+    $this->addUsage('site:aliases');
+    $this->addUsage('--drall-group=GROUP site:aliases');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Commands/SiteAliasesCommand.php
+++ b/src/Commands/SiteAliasesCommand.php
@@ -3,6 +3,7 @@
 namespace Drall\Commands;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -14,10 +15,18 @@ class SiteAliasesCommand extends BaseCommand {
     $this->setName('site:aliases');
     $this->setAliases(['sa']);
     $this->setDescription('Get a list of site aliases.');
+    $this->addOption(
+      'drall-group',
+      NULL,
+      InputOption::VALUE_REQUIRED,
+      'Site group identifier.'
+    );
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $aliases = $this->siteDetector()->getSiteAliases();
+    $aliases = $this->siteDetector()->getSiteAliases(
+      $input->getOption('drall-group')
+    );
 
     if (count($aliases) === 0) {
       $this->logger->warning('No site aliases found.');

--- a/src/Commands/SiteDirectoriesCommand.php
+++ b/src/Commands/SiteDirectoriesCommand.php
@@ -15,12 +15,16 @@ class SiteDirectoriesCommand extends BaseCommand {
     $this->setName('site:directories');
     $this->setAliases(['sd']);
     $this->setDescription('Get a list of site directories.');
+
     $this->addOption(
       'drall-group',
       NULL,
       InputOption::VALUE_REQUIRED,
       'Site group identifier.'
     );
+
+    $this->addUsage('site:directories');
+    $this->addUsage('--drall-group=GROUP site:directories');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/Commands/SiteDirectoriesCommand.php
+++ b/src/Commands/SiteDirectoriesCommand.php
@@ -3,6 +3,7 @@
 namespace Drall\Commands;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -14,10 +15,18 @@ class SiteDirectoriesCommand extends BaseCommand {
     $this->setName('site:directories');
     $this->setAliases(['sd']);
     $this->setDescription('Get a list of site directories.');
+    $this->addOption(
+      'drall-group',
+      NULL,
+      InputOption::VALUE_REQUIRED,
+      'Site group identifier.'
+    );
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $dirNames = $this->siteDetector()->getSiteDirNames();
+    $dirNames = $this->siteDetector()->getSiteDirNames(
+      $input->getOption('drall-group')
+    );
 
     if (count($dirNames) === 0) {
       $this->logger->warning('No site directories found.');

--- a/src/Drall.php
+++ b/src/Drall.php
@@ -63,19 +63,24 @@ final class Drall extends Application {
     $this->setDefaultCommand($cmd->getName());
   }
 
+  /**
+   * {@inheritdoc}
+   *
+   * Based on Drush/Application::configureIO().
+   */
   protected function configureIO(InputInterface $input, OutputInterface $output) {
     parent::configureIO($input, $output);
 
-    // Symfony will set these later, but we want it set upfront
-    if ($input->getParameterOption(['--verbose', '-v'], false, true) !== false) {
+    // Symfony will set these later, but we want it set upfront.
+    if ($input->getParameterOption(['--verbose', '-v'], FALSE, TRUE) !== FALSE) {
       $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
     }
-    // We are not using "very verbose", but set this for completeness
-    if ($input->getParameterOption(['-vv'], false, true) !== false) {
+    // We are not using "very verbose", but set this for completeness.
+    if ($input->getParameterOption(['-vv'], FALSE, TRUE) !== FALSE) {
       $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
     }
     // Use -vvv of --debug for even more verbose logging.
-    if ($input->getParameterOption(['--debug', '-d', '-vvv'], false, true) !== false) {
+    if ($input->getParameterOption(['--debug', '-d', '-vvv'], FALSE, TRUE) !== FALSE) {
       $output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
     }
   }

--- a/src/Drall.php
+++ b/src/Drall.php
@@ -59,8 +59,6 @@ final class Drall extends Application {
     $cmd->setSiteDetector($siteDetector);
     $cmd->setLogger($this->logger);
     $this->add($cmd);
-
-    $this->setDefaultCommand($cmd->getName());
   }
 
   /**

--- a/src/Models/SitesFile.php
+++ b/src/Models/SitesFile.php
@@ -34,12 +34,12 @@ class SitesFile {
    */
   private function getEntries() {
     if (!is_file($this->path)) {
-      throw new \RuntimeException("Cannot read sites file: {$this->path}");
+      throw new \RuntimeException("Cannot read sites file: $this->path");
     }
 
     require $this->path;
     if (!isset($sites) || !is_array($sites)) {
-      throw new \RuntimeException("Site declarations not found in file: {$this->path}");
+      throw new \RuntimeException("Site declarations not found in file: $this->path");
     }
 
     return $sites;

--- a/src/Models/SitesFile.php
+++ b/src/Models/SitesFile.php
@@ -17,6 +17,16 @@ class SitesFile {
   }
 
   /**
+   * Get the path to the sites file.
+   *
+   * @return string
+   *   Path to the file.
+   */
+  public function getPath(): string {
+    return $this->path;
+  }
+
+  /**
    * Get the value of the $sites variable.
    *
    * @return array

--- a/src/Services/SiteDetector.php
+++ b/src/Services/SiteDetector.php
@@ -62,11 +62,15 @@ class SiteDetector {
    * @return array
    *   An array of site alias names with the @ prefix.
    */
-  public function getSiteAliasNames(): array {
-    $result = array_map(function ($alias) {
-      return explode('.', $alias->name())[0];
-    }, $this->siteAliasManager()->getMultiple());
+  public function getSiteAliasNames(string $group = NULL): array {
+    $result = [];
+    foreach ($this->siteAliasManager()->getMultiple() as $siteAlias) {
+      if ($group && !in_array($group, $siteAlias->get('drall.groups') ?? [])) {
+        continue;
+      }
 
+      $result[] = explode('.', $siteAlias->name())[0];
+    }
     return array_unique(array_values($result));
   }
 

--- a/src/Services/SiteDetector.php
+++ b/src/Services/SiteDetector.php
@@ -29,9 +29,17 @@ class SiteDetector {
     return $drupalRoot;
   }
 
-  public function getSiteDirNames(): array {
-    $drupalRoot = $this->getDrupalRoot();
-    $sitesFile = new SitesFile("$drupalRoot/sites/sites.php");
+  /**
+   * Get a list of site directory names for a site group.
+   *
+   * @param string|null $group
+   *   A site group, if any.
+   *
+   * @return array
+   *   Contents of the $sites variable.
+   */
+  public function getSiteDirNames(string $group = NULL): array {
+    $sitesFile = $this->getSitesFile($group);
     return $sitesFile->getDirNames();
   }
 
@@ -60,6 +68,17 @@ class SiteDetector {
     }, $this->siteAliasManager()->getMultiple());
 
     return array_unique(array_values($result));
+  }
+
+  private function getSitesFile($group = NULL): SitesFile {
+    $drupalRoot = $this->getDrupalRoot();
+
+    $basename = 'sites.php';
+    if ($group) {
+      $basename = "sites.$group.php";
+    }
+
+    return new SitesFile("$drupalRoot/sites/$basename");
   }
 
 }


### PR DESCRIPTION
## What's done

- Allows creating site groups.
- Allows running commands on specific site groups with `--drall-group=GROUP` option.