### PR TITLE
Add support for a --root option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,14 +141,17 @@ Specify a Drupal project root or document root directory.
 
     drall --root=/path/to/drupal site:directories
 
+### --drall-group
+
+Specify the target site group. See the section *site groups* for more
+information on site groups.
+
+    drall exec:drush --drall-group=GROUP core:status --field=site
+
 ## Site groups
 
-Drall allows you to group your sites so that you can run commands on such
-groups with ease.
-
-```
-drall exec:drush --drall-group=GROUP core:rebuild
-```
+Drall allows you to group your sites so that you can run commands on these
+groups using the `--drall-group` option.
 
 ### Drall groups with site aliases
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ do
 done;
 ```
 
+## Global options
+
+This section covers some options that are supported by all `drall` commands.
+
+### --root
+
+Specify a Drupal project root or document root directory.
+
+    drall --root=/path/to/drupal site:directories
+
 ## Site groups
 
 Drall allows you to group your sites so that you can run commands on such

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -5,10 +5,20 @@ namespace Drall\Commands;
 use Drall\Traits\SiteDetectorAwareTrait;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
 
 abstract class BaseCommand extends Command {
 
   use LoggerAwareTrait;
   use SiteDetectorAwareTrait;
+
+  protected function configure() {
+    $this->addOption(
+      'root',
+      NULL,
+      InputOption::VALUE_OPTIONAL,
+      'Drupal root or Composer root.'
+    );
+  }
 
 }

--- a/src/Commands/ExecCommand.php
+++ b/src/Commands/ExecCommand.php
@@ -71,6 +71,8 @@ class ExecCommand extends BaseCommand {
   }
 
   protected function configure() {
+    parent::configure();
+
     $this->setName('exec:drush');
     $this->setAliases(['exec', 'ex', 'exd']);
     $this->setDescription('Execute a drush command.');

--- a/src/Commands/SiteAliasesCommand.php
+++ b/src/Commands/SiteAliasesCommand.php
@@ -12,6 +12,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 class SiteAliasesCommand extends BaseCommand {
 
   protected function configure() {
+    parent::configure();
+
     $this->setName('site:aliases');
     $this->setAliases(['sa']);
     $this->setDescription('Get a list of site aliases.');

--- a/src/Commands/SiteDirectoriesCommand.php
+++ b/src/Commands/SiteDirectoriesCommand.php
@@ -12,6 +12,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 class SiteDirectoriesCommand extends BaseCommand {
 
   protected function configure() {
+    parent::configure();
+
     $this->setName('site:directories');
     $this->setAliases(['sd']);
     $this->setDescription('Get a list of site directories.');

--- a/test/Integration/Commands/SiteAliasesCommandTest.php
+++ b/test/Integration/Commands/SiteAliasesCommandTest.php
@@ -45,4 +45,30 @@ EOF, $output);
 EOF, $output);
   }
 
+  public function testWithComposerRoot() {
+    chdir('/');
+    $output = shell_exec('drall --root=' . $this->drupalDir() . ' site:aliases');
+    $this->assertEquals(<<<EOF
+@donnie.local
+@leo.local
+@mikey.local
+@ralph.local
+@tmnt.local
+
+EOF, $output);
+  }
+
+  public function testWithDrupalRoot() {
+    chdir('/');
+    $output = shell_exec('drall --root=' . $this->drupalDir() . '/web site:aliases');
+    $this->assertEquals(<<<EOF
+@donnie.local
+@leo.local
+@mikey.local
+@ralph.local
+@tmnt.local
+
+EOF, $output);
+  }
+
 }

--- a/test/Integration/Commands/SiteDirectoriesCommandTest.php
+++ b/test/Integration/Commands/SiteDirectoriesCommandTest.php
@@ -45,4 +45,30 @@ leo
 EOF, $output);
   }
 
+  public function testWithComposerRoot() {
+    chdir('/');
+    $output = shell_exec('drall --root=' . $this->drupalDir() . ' site:directories');
+    $this->assertEquals(<<<EOF
+default
+donnie
+leo
+mikey
+ralph
+
+EOF, $output);
+  }
+
+  public function testWithDrupalRoot() {
+    chdir('/');
+    $output = shell_exec('drall --root=' . $this->drupalDir() . '/web site:directories');
+    $this->assertEquals(<<<EOF
+default
+donnie
+leo
+mikey
+ralph
+
+EOF, $output);
+  }
+
 }


### PR DESCRIPTION
## What’s done

- Adds support for a `--root` option in all commands.
- This lets a user run `drall` from any `pwd` and still target a specific Drupal installation.

### Example

    drall --root=/path/to/drupal site:directories
    drall exec:drush --drall-group=bluish core:status --fields=site