### PR TITLE
Add support for DRALL_GROUP environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ information on site groups.
 
     drall exec:drush --drall-group=GROUP core:status --field=site
 
+If `--drall-group` is not set, then the Drall uses the environment variable
+`DRALL_GROUP`, if it is set.
+
 ## Site groups
 
 Drall allows you to group your sites so that you can run commands on these

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -5,6 +5,7 @@ namespace Drall\Commands;
 use Drall\Traits\SiteDetectorAwareTrait;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 
 abstract class BaseCommand extends Command {
@@ -26,6 +27,23 @@ abstract class BaseCommand extends Command {
       InputOption::VALUE_OPTIONAL,
       'Site group identifier.'
     );
+  }
+
+  /**
+   * Gets the active Drall group.
+   *
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   *   The input.
+   *
+   * @return null|string
+   *   Drall group, if any. Otherwise, NULL.
+   */
+  protected function getDrallGroup(InputInterface $input): ?string {
+    if ($group = $input->getOption('drall-group')) {
+      return $group;
+    }
+
+    return getenv('DRALL_GROUP') ?: NULL;
   }
 
 }

--- a/src/Commands/BaseExecCommand.php
+++ b/src/Commands/BaseExecCommand.php
@@ -87,7 +87,7 @@ abstract class BaseExecCommand extends BaseCommand {
     InputInterface $input,
     OutputInterface $output
   ): int {
-    $siteGroup = $input->getOption('drall-group');
+    $siteGroup = $this->getDrallGroup($input);
 
     if ($command->hasPlaceholder('uri') && $command->hasPlaceholder('site')) {
       $this->logger->error('The command cannot contain both @@uri and @@site placeholders.');

--- a/src/Commands/SiteAliasesCommand.php
+++ b/src/Commands/SiteAliasesCommand.php
@@ -21,9 +21,8 @@ class SiteAliasesCommand extends BaseCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $aliases = $this->siteDetector()->getSiteAliases(
-      $input->getOption('drall-group')
-    );
+    $aliases = $this->siteDetector()
+      ->getSiteAliases($this->getDrallGroup($input));
 
     if (count($aliases) === 0) {
       $this->logger->warning('No site aliases found.');

--- a/src/Commands/SiteDirectoriesCommand.php
+++ b/src/Commands/SiteDirectoriesCommand.php
@@ -21,9 +21,8 @@ class SiteDirectoriesCommand extends BaseCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $dirNames = $this->siteDetector()->getSiteDirNames(
-      $input->getOption('drall-group')
-    );
+    $dirNames = $this->siteDetector()
+      ->getSiteDirNames($this->getDrallGroup($input));
 
     if (count($dirNames) === 0) {
       $this->logger->warning('No Drupal sites found.');

--- a/src/Services/SiteDetector.php
+++ b/src/Services/SiteDetector.php
@@ -71,7 +71,7 @@ class SiteDetector {
    * @return array
    *   An array of site alias names with the @ prefix.
    */
-  public function getSiteAliasNames(string $group = NULL): array {
+  public function getSiteAliasNames(?string $group = NULL): array {
     $result = array_map(function ($siteAlias) {
       return explode('.', $siteAlias)[0];
     }, $this->getSiteAliases($group));

--- a/test/Integration/Commands/SiteAliasesCommandTest.php
+++ b/test/Integration/Commands/SiteAliasesCommandTest.php
@@ -45,6 +45,18 @@ EOF, $output);
 EOF, $output);
   }
 
+  /**
+   * Run site:aliases with DRALL_GROUP env var.
+   */
+  public function testWithGroupEnvVar(): void {
+    $output = shell_exec('DRALL_GROUP=reddish drall site:aliases');
+    $this->assertOutputEquals(<<<EOF
+@mikey.local
+@ralph.local
+
+EOF, $output);
+  }
+
   public function testWithComposerRoot() {
     chdir('/');
     $output = shell_exec('drall --root=' . $this->drupalDir() . ' site:aliases');

--- a/test/Integration/Commands/SiteDirectoriesCommandTest.php
+++ b/test/Integration/Commands/SiteDirectoriesCommandTest.php
@@ -45,6 +45,18 @@ leo
 EOF, $output);
   }
 
+  /**
+   * Run site:directories with DRALL_GROUP env var.
+   */
+  public function testWithGroupEnvVar(): void {
+    $output = shell_exec('DRALL_GROUP=bluish drall site:directories');
+    $this->assertOutputEquals(<<<EOF
+donnie
+leo
+
+EOF, $output);
+  }
+
   public function testWithComposerRoot() {
     chdir('/');
     $output = shell_exec('drall --root=' . $this->drupalDir() . ' site:directories');

--- a/test/Unit/Commands/SiteAliasesCommandTest.php
+++ b/test/Unit/Commands/SiteAliasesCommandTest.php
@@ -9,6 +9,7 @@ use Drall\Services\SiteDetector;
 use Drall\TestCase;
 
 /**
+ * @covers \Drall\Commands\BaseCommand
  * @covers \Drall\Commands\SiteAliasesCommand
  */
 class SiteAliasesCommandTest extends TestCase {

--- a/test/Unit/Commands/SiteDirectoriesCommandTest.php
+++ b/test/Unit/Commands/SiteDirectoriesCommandTest.php
@@ -9,6 +9,7 @@ use Drall\Services\SiteDetector;
 use Drall\TestCase;
 
 /**
+ * @covers \Drall\Commands\BaseCommand
  * @covers \Drall\Commands\SiteDirectoriesCommand
  */
 class SiteDirectoriesCommandTest extends TestCase {


### PR DESCRIPTION
## What’s done

- [x] Fall back to `DRALL_GROUP` env var when `--drall-group` is not specified.
- [x] Update tests
- [x] Update README