### PR TITLE
Allow running multiple commands in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ If `--drall-group` is not set, then the Drall uses the environment variable
 
 Whether Drall should display verbose output.
 
+### --drall-debug
+
+Whether Drall should display debugging output.
+
 ## Site groups
 
 Drall allows you to group your sites so that you can run commands on these

--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ the initial development of Drall.
 Drall is listed on [Packagist.org](https://packagist.org/packages/jigarius/drall).
 Thus, it can easily be installed using `composer` as follows:
 
-```
-composer require jigarius/drall
-```
+  composer require jigarius/drall
 
 ## Commands
 
@@ -31,15 +29,11 @@ There are a number of ways to run `drush` commands on multiple sites.
 
 In this method, the `--uri` option is sent to `drush`.
 
-```
-drall exec:drush --uri=@@uri core:status
-```
+  drall exec:drush --uri=@@uri core:status
 
 Or simplify omit the `--uri=@@uri` and it will be added automatically.
 
-```
-drall exec:drush core:status
-```
+  drall exec:drush core:status
 
 ##### Example
 
@@ -59,13 +53,11 @@ in which the various sites live.
 
 In this method, a site alias is sent to `drush`.
 
-```
-drall exec:drush @@site.local core:status
-```
+  drall exec:drush @@site.local core:status
 
 ##### Example
 
-```
+```shell
 $ drall exec:drush @@site.local core:status
 drush @tmnt.local core:status
 drush @donnie.local core:status
@@ -91,7 +83,7 @@ you use `@@uri` and you cannot mix it with `@@site`.
 
 #### Example: Usage
 
-```
+```shell
 $ drall exec:shell cat web/sites/@@uri/settings.local.php
 cat web/sites/default/settings.local.php
 cat web/sites/donnie/settings.local.php
@@ -102,9 +94,7 @@ cat web/sites/ralph/settings.local.php
 
 #### Example: Multiple commands
 
-```
-$ drall exec:shell "drush @@site.dev updb -y && drush @@site.dev cim -y && drush @@site.dev cr"
-```
+  drall exec:shell "drush @@site.dev updb -y && drush @@site.dev cim -y && drush @@site.dev cr"
 
 ### site:directories
 
@@ -140,7 +130,7 @@ Get a list of site aliases.
 
 #### Example: Usage
 
-```
+```shell
 $ drall site:aliases
 @tmnt.local
 @donnie.local
@@ -241,16 +231,14 @@ To access the dev sites in your browser, add the following line to your hosts
 file. It is usually located at `/etc/hosts`. This is completely optional, so
 do this only if you need it.
 
-```
-127.0.0.1 tmnt.drall.local donnie.drall.local leo.drall.local mikey.drall.local ralph.drall.local
-```
+  127.0.0.1 tmnt.drall.local donnie.drall.local leo.drall.local mikey.drall.local ralph.drall.local
 
 The sites should then be available at:
-- http://tmnt.drall.local/
-- http://donnie.drall.local/
-- http://leo.drall.local/
-- http://mikey.drall.local/
-- http://ralph.drall.local/
+- [tmnt.drall.local](http://tmnt.drall.local/)
+- [donnie.drall.local](http://donnie.drall.local/)
+- [leo.drall.local](http://leo.drall.local/)
+- [mikey.drall.local](http://mikey.drall.local/)
+- [ralph.drall.local](http://ralph.drall.local/)
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ information on site groups.
 If `--drall-group` is not set, then the Drall uses the environment variable
 `DRALL_GROUP`, if it is set.
 
+### --drall-verbose
+
+Whether Drall should display verbose output.
+
 ## Site groups
 
 Drall allows you to group your sites so that you can run commands on these

--- a/README.md
+++ b/README.md
@@ -215,6 +215,25 @@ $sites['leo.drall.local'] = 'leo';
 
 This puts the sites `donnie` and `leo` in a group named `bluish`.
 
+## Parallel execution
+
+Say you have 100 sites in a Drupal installation. By default, Drall runs
+commands on these sites one after the other. To speed up the execution, you
+can ask Drall to execute multiple commands in parallel. You can specify the
+number of workers with the `--drall-workers=n` option, where `n` is the
+number of processes you want to run in parallel.
+
+Please keep in mind that running a high number of workers can create problems!
+The maximum number of workers allowed is set to `10` at the moment.
+
+### Example: Parallel execution
+
+The command below launches 3 instances of Drall to run `core:rebuild` command.
+
+  drall exec:drush core:rebuild --drall-workers=3
+
+When a worker runs out of work, it terminates automatically.
+
 ## Development
 
 Here's how you can set up a local dev environment.

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -17,31 +17,10 @@ abstract class BaseCommand extends Command {
 
   protected function configure() {
     $this->addOption(
-      'root',
-      NULL,
-      InputOption::VALUE_OPTIONAL,
-      'Drupal root or Composer root.'
-    );
-
-    $this->addOption(
       'drall-group',
       NULL,
       InputOption::VALUE_OPTIONAL,
       'Site group identifier.'
-    );
-
-    $this->addOption(
-      'drall-verbose',
-      NULL,
-      InputOption::VALUE_NONE,
-      'Display verbose output.'
-    );
-
-    $this->addOption(
-      'drall-debug',
-      NULL,
-      InputOption::VALUE_NONE,
-      'Display debugging output.'
     );
   }
 

--- a/src/Commands/BaseExecCommand.php
+++ b/src/Commands/BaseExecCommand.php
@@ -94,14 +94,20 @@ abstract class BaseExecCommand extends BaseCommand {
     $placeholder = $this->getPlaceholderName($command);
 
     // Get all values for the placeholder.
-    if ($placeholder === 'uri') {
-      // @todo Should the keys of the $sites array be used instead?
-      // @todo Can sites exist with sites/GROUP/SITE/settings.php?
-      //   If yes, then does --uri=GROUP/SITE work correctly?
-      $values = $this->siteDetector()->getSiteDirNames($siteGroup);
-    }
-    else {
-      $values = $this->siteDetector()->getSiteAliasNames($siteGroup);
+    switch ($placeholder) {
+      case 'uri':
+        // @todo Should the keys of the $sites array be used instead?
+        // @todo Can sites exist with sites/GROUP/SITE/settings.php?
+        //   If yes, then does --uri=GROUP/SITE work correctly?
+        $values = $this->siteDetector()->getSiteDirNames($siteGroup);
+        break;
+
+      case 'site':
+        $values = $this->siteDetector()->getSiteAliasNames($siteGroup);
+        break;
+
+      default:
+        return 1;
     }
 
     if (empty($values)) {

--- a/src/Commands/BaseExecCommand.php
+++ b/src/Commands/BaseExecCommand.php
@@ -117,6 +117,12 @@ abstract class BaseExecCommand extends BaseCommand {
 
     // If multiple workers are required.
     $w = $input->getOption('drall-workers');
+
+    if ($w > 10) {
+      $this->logger->warning('Limiting workers to 10, which is the maximum.');
+      $w = 10;
+    }
+
     if ($w > 1) {
       $this->logger->info("Executing with $w workers.");
 

--- a/src/Commands/BaseExecCommand.php
+++ b/src/Commands/BaseExecCommand.php
@@ -149,6 +149,8 @@ abstract class BaseExecCommand extends BaseCommand {
       $all = implode(' && ', $workerCommands);
       $this->runner->execute($all);
 
+      // @todo Do not terminate until all items are processed?
+      //   Display summary of all the failures?
       return 0;
     }
 

--- a/src/Commands/ExecQueueCommand.php
+++ b/src/Commands/ExecQueueCommand.php
@@ -97,8 +97,8 @@ class ExecQueueCommand extends BaseCommand {
       //   able to redirect the output to a log file, if required. Or maybe
       //   add support for a --drall-log-file option which will make all the
       //   workers write to the same log file.
-      $output->write($this->runner->getOutput());
       $this->logger->info("$prefix Finished: $shellCommand");
+      $output->write($this->runner->getOutput());
       $outputLock->release();
     }
 

--- a/src/Commands/ExecQueueCommand.php
+++ b/src/Commands/ExecQueueCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Drall\Commands;
+
+use Drall\Models\Lock;
+use Drall\Models\Queue\File as QueueFile;
+use Drall\Runners\ExecRunner;
+use Drall\Traits\RunnerAwareTrait;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * A command to execute a drush command on multiple sites.
+ */
+class ExecQueueCommand extends BaseCommand {
+
+  use RunnerAwareTrait;
+
+  public function __construct(string $name = NULL) {
+    parent::__construct($name);
+    $this->argv = $GLOBALS['argv'];
+    $this->setRunner(new ExecRunner());
+  }
+
+  protected function configure() {
+    parent::configure();
+
+    $this->setName('exec:queue');
+    $this->setDescription('Start a queue worker.');
+    $this->setAliases(['exq']);
+    $this->addArgument('drallq-file', InputArgument::REQUIRED);
+    $this->addUsage('/path/to/drallq.json');
+    $this->setHidden();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output): int {
+    $prefix = '[pid:' . getmypid() . ']';
+    $qPath = $input->getArgument('drallq-file');
+    $qPath = realpath($qPath);
+
+    if (!$qPath) {
+      $this->logger->error("Queue file not found: $qPath");
+      return 1;
+    }
+
+    $qFile = new QueueFile($qPath);
+    $qLock = new Lock("$qPath.rw.lock");
+    $outputLock = new Lock("$qPath.output.lock");
+
+    // Run until we run out of items to process.
+    while (TRUE) {
+      $qLock->acquire(TRUE);
+      $this->logger->debug("$prefix Queue lock acquired.");
+
+      $qData = $qFile->read();
+      $item = $qData->next();
+      // This way, other workers know that an item has been taken by this worker.
+      $qFile->write($qData);
+      $qLock->release();
+      $this->logger->debug("$prefix Queue lock released.");
+
+      // No more items left? Then we're done.
+      if (!$item) {
+        $this->logger->debug("$prefix Nothing left to do.");
+        break;
+      }
+
+      // Process the item, i.e. run the command.
+      $rawCommand = $qData->getCommand();
+      $placeholder = $qData->getPlaceholder();
+      $shellCommand = $rawCommand->with([$placeholder => $item->getId()]);
+      $this->logger->debug("Running: $shellCommand");
+
+      $this->runner()->execute($shellCommand);
+
+      // Mark the item as done.
+      $qLock->acquire(TRUE);
+      $this->logger->debug("$prefix Queue lock acquired.");
+
+      $qData = $qFile->read();
+      $qData->markAsDone($item);
+      $qFile->write($qData);
+
+      $this->logger->debug("$prefix Queue lock released.");
+      $qLock->release();
+
+      $outputLock->acquire(TRUE);
+      $output->write($this->runner->getOutput());
+      $outputLock->release();
+    }
+
+    return 0;
+  }
+
+}

--- a/src/Drall.php
+++ b/src/Drall.php
@@ -37,6 +37,7 @@ final class Drall extends Application {
     parent::__construct();
     $this->setName(self::NAME);
     $this->setVersion(self::VERSION);
+    $this->setAutoExit(FALSE);
 
     $input = $input ?? new ArgvInput();
     $root = $input->getParameterOption('--root') ?: getcwd();

--- a/src/Drall.php
+++ b/src/Drall.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class Drall extends Application {
@@ -34,12 +35,10 @@ final class Drall extends Application {
     ?InputInterface $input = NULL
   ) {
     parent::__construct();
-
-    $input = $input ?? new ArgvInput();
-
     $this->setName(self::NAME);
     $this->setVersion(self::VERSION);
 
+    $input = $input ?? new ArgvInput();
     $root = $input->getParameterOption('--root') ?: getcwd();
     $siteDetector ??= $this->createDefaultSiteDetector($root);
     $this->setSiteDetector($siteDetector);
@@ -62,7 +61,6 @@ final class Drall extends Application {
 
     $cmd = new ExecQueueCommand();
     $cmd->setSiteDetector($siteDetector);
-    $cmd->setLogger($this->logger);
     $this->add($cmd);
   }
 
@@ -82,9 +80,30 @@ final class Drall extends Application {
 
   protected function getDefaultInputDefinition(): InputDefinition {
     $definition = parent::getDefaultInputDefinition();
+
+    // Remove unneeded options.
     $options = $definition->getOptions();
     unset($options['verbose'], $options['quiet']);
     $definition->setOptions($options);
+
+    $definition->addOption(new InputOption(
+      'drall-verbose',
+      NULL,
+      InputOption::VALUE_NONE,
+      'Display verbose output for Drall.'
+    ));
+    $definition->addOption(new InputOption(
+      'drall-debug',
+      NULL,
+      InputOption::VALUE_NONE,
+      'Display debugging output for Drall.'
+    ));
+    $definition->addOption(new InputOption(
+      'root',
+      NULL,
+      InputOption::VALUE_OPTIONAL,
+      'Drupal root or Composer root.'
+    ));
 
     return $definition;
   }

--- a/src/Drall.php
+++ b/src/Drall.php
@@ -39,6 +39,10 @@ final class Drall extends Application {
     $this->setVersion(self::VERSION);
     $this->setAutoExit(FALSE);
 
+    // @todo Instead of using $input to create a SiteDetector here, we can
+    //   create the SiteDetector in BaseCommand::preExecute(). That way,
+    //   we won't need this extra dependency injection, thereby simplifying
+    //   the code and the tests.
     $input = $input ?? new ArgvInput();
     $root = $input->getParameterOption('--root') ?: getcwd();
     $siteDetector ??= $this->createDefaultSiteDetector($root);

--- a/src/Drall.php
+++ b/src/Drall.php
@@ -5,6 +5,7 @@ namespace Drall;
 use Consolidation\SiteAlias\SiteAliasManager;
 use Drall\Commands\ExecShellCommand;
 use Drall\Commands\ExecDrushCommand;
+use Drall\Commands\ExecQueueCommand;
 use Drall\Commands\SiteDirectoriesCommand;
 use Drall\Commands\SiteAliasesCommand;
 use Drall\Services\SiteDetector;
@@ -57,6 +58,11 @@ final class Drall extends Application {
 
     $cmd = new ExecShellCommand();
     $cmd->setSiteDetector($siteDetector);
+    $this->add($cmd);
+
+    $cmd = new ExecQueueCommand();
+    $cmd->setSiteDetector($siteDetector);
+    $cmd->setLogger($this->logger);
     $this->add($cmd);
   }
 

--- a/test/Unit/Commands/ExecQueueCommandTest.php
+++ b/test/Unit/Commands/ExecQueueCommandTest.php
@@ -41,7 +41,7 @@ class ExecQueueCommandTest extends TestCase {
     $qFile = new File($this->createTempFilePath());
     $qData = new Queue(
       'x.y.z',
-      new RawCommand('echo "We at @@uri"'),
+      new RawCommand('echo "We at @@uri."'),
       'uri'
     );
     $qData->push(new Item('default'));
@@ -57,9 +57,9 @@ class ExecQueueCommandTest extends TestCase {
 
     $this->assertEquals(
       <<<EOF
-[info] [drall:test] Started: echo "We at default"
-We at default
-[info] [drall:test] Finished: echo "We at default"
+[info] [drall:test] Started: echo "We at default."
+[info] [drall:test] Finished: echo "We at default."
+We at default.
 EOF,
       trim($tester->getDisplay(TRUE)),
     );

--- a/test/Unit/Commands/ExecQueueCommandTest.php
+++ b/test/Unit/Commands/ExecQueueCommandTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Symfony\Component\Console\Tester\ApplicationTester;
+use Drall\Drall;
+use Drall\Commands\BaseExecCommand;
+use Drall\Commands\ExecDrushCommand;
+use Drall\Models\Queue\File;
+use Drall\Models\Queue\Item;
+use Drall\Models\Queue\Queue;
+use Drall\Models\RawCommand;
+use Drall\TestCase;
+
+/**
+ * @covers \Drall\Commands\ExecQueueCommand
+ * @covers \Drall\Commands\BaseExecCommand
+ */
+class ExecQueueCommandTest extends TestCase {
+
+  public function testExtendsBaseCommand() {
+    $this->assertTrue(is_subclass_of(ExecDrushCommand::class, BaseExecCommand::class));
+  }
+
+  public function testExecuteWithNonExistentQueueFile() {
+    $qPath = $this->createTempFilePath();
+    unlink($qPath);
+
+    $tester = new ApplicationTester(new Drall());
+    $tester->run([
+      'command' => 'exec:queue',
+      'drallq-file' => $qPath,
+      '--drall-verbose' => TRUE,
+    ]);
+
+    $this->assertEquals(
+      "[error] Queue file not found: $qPath" . PHP_EOL,
+      $tester->getDisplay(),
+    );
+  }
+
+  public function testExecute() {
+    $qFile = new File($this->createTempFilePath());
+    $qData = new Queue(
+      'x.y.z',
+      new RawCommand('echo "We at @@uri"'),
+      'uri'
+    );
+    $qData->push(new Item('default'));
+    $qFile->write($qData);
+
+    $tester = new ApplicationTester(new Drall());
+    $tester->run([
+      'command' => 'exec:queue',
+      'drallq-file' => $qFile->getPath(),
+      '--drall-worker-id' => 'test',
+      '--drall-verbose' => TRUE,
+    ]);
+
+    $this->assertEquals(
+      <<<EOF
+[info] [drall:test] Started: echo "We at default"
+We at default
+[info] [drall:test] Finished: echo "We at default"
+EOF,
+      trim($tester->getDisplay(TRUE)),
+    );
+  }
+
+}

--- a/test/Unit/DrallTest.php
+++ b/test/Unit/DrallTest.php
@@ -4,6 +4,9 @@ namespace Unit;
 
 use Drall\Drall;
 use Drall\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 /**
  * @covers \Drall\Drall
@@ -37,6 +40,44 @@ class DrallTest extends TestCase {
     $this->assertArrayNotHasKey('verbose', $options);
     $this->assertArrayHasKey('drall-verbose', $options);
     $this->assertArrayHasKey('drall-debug', $options);
+  }
+
+  public function testOptionVerbosityNormal() {
+    $output = new ConsoleOutput();
+    $input = new ArgvInput([
+      '/path/to/drall',
+      'exec:drush',
+      'core:status',
+    ]);
+    new Drall(NULL, $input, $output);
+
+    $this->assertEquals(OutputInterface::VERBOSITY_NORMAL, $output->getVerbosity());
+  }
+
+  public function testOptionVerbosityVerbose() {
+    $output = new ConsoleOutput();
+    $input = new ArgvInput([
+      '/path/to/drall',
+      'exec:drush',
+      'core:status',
+      '--drall-verbose',
+    ]);
+    new Drall(NULL, $input, $output);
+
+    $this->assertEquals(OutputInterface::VERBOSITY_VERY_VERBOSE, $output->getVerbosity());
+  }
+
+  public function testOptionVerbosityDebug() {
+    $output = new ConsoleOutput();
+    $input = new ArgvInput([
+      '/path/to/drall',
+      'exec:drush',
+      'core:status',
+      '--drall-debug',
+    ]);
+    new Drall(NULL, $input, $output);
+
+    $this->assertEquals(OutputInterface::VERBOSITY_DEBUG, $output->getVerbosity());
   }
 
 }

--- a/test/Unit/DrallTest.php
+++ b/test/Unit/DrallTest.php
@@ -29,4 +29,14 @@ class DrallTest extends TestCase {
     $this->assertEquals($json_data->version, $app->getVersion());
   }
 
+  public function testDefaultInputOptions() {
+    $app = new Drall();
+    $options = $app->getDefinition()->getOptions();
+
+    $this->assertArrayNotHasKey('quiet', $options);
+    $this->assertArrayNotHasKey('verbose', $options);
+    $this->assertArrayHasKey('drall-verbose', $options);
+    $this->assertArrayHasKey('drall-debug', $options);
+  }
+
 }

--- a/test/Unit/DrallTest.php
+++ b/test/Unit/DrallTest.php
@@ -5,8 +5,7 @@ namespace Unit;
 use Drall\Drall;
 use Drall\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Tester\ApplicationTester;
 
 /**
  * @covers \Drall\Drall
@@ -43,41 +42,21 @@ class DrallTest extends TestCase {
   }
 
   public function testOptionVerbosityNormal() {
-    $output = new ConsoleOutput();
-    $input = new ArgvInput([
-      '/path/to/drall',
-      'exec:drush',
-      'core:status',
-    ]);
-    new Drall(NULL, $input, $output);
-
-    $this->assertEquals(OutputInterface::VERBOSITY_NORMAL, $output->getVerbosity());
+    $tester = new ApplicationTester(new Drall());
+    $tester->run(['command' => 'version']);
+    $this->assertEquals(OutputInterface::VERBOSITY_NORMAL, $tester->getOutput()->getVerbosity());
   }
 
   public function testOptionVerbosityVerbose() {
-    $output = new ConsoleOutput();
-    $input = new ArgvInput([
-      '/path/to/drall',
-      'exec:drush',
-      'core:status',
-      '--drall-verbose',
-    ]);
-    new Drall(NULL, $input, $output);
-
-    $this->assertEquals(OutputInterface::VERBOSITY_VERY_VERBOSE, $output->getVerbosity());
+    $tester = new ApplicationTester(new Drall());
+    $tester->run(['command' => 'version', '--drall-verbose' => TRUE]);
+    $this->assertEquals(OutputInterface::VERBOSITY_VERY_VERBOSE, $tester->getOutput()->getVerbosity());
   }
 
   public function testOptionVerbosityDebug() {
-    $output = new ConsoleOutput();
-    $input = new ArgvInput([
-      '/path/to/drall',
-      'exec:drush',
-      'core:status',
-      '--drall-debug',
-    ]);
-    new Drall(NULL, $input, $output);
-
-    $this->assertEquals(OutputInterface::VERBOSITY_DEBUG, $output->getVerbosity());
+    $tester = new ApplicationTester(new Drall());
+    $tester->run(['command' => 'version', '--drall-debug' => TRUE]);
+    $this->assertEquals(OutputInterface::VERBOSITY_DEBUG, $tester->getOutput()->getVerbosity());
   }
 
 }

--- a/test/Unit/Runners/FakeRunnerTest.php
+++ b/test/Unit/Runners/FakeRunnerTest.php
@@ -27,4 +27,9 @@ class FakeRunnerTest extends TestCase {
     $this->assertEquals(['foo', 'bar', 'baz'], $runner->commandHistory());
   }
 
+  public function testGetOutput() {
+    $runner = new FakeRunner();
+    $this->assertNull($runner->getOutput());
+  }
+
 }


### PR DESCRIPTION
## Tasks

- [x] PR: Issue #38 
- [x] PR: Create and use `RunnerAwareTrait`.
- [x] PR: Create `ExecRunner` which should use `exec()` for capturing output and exit code.
- [x] PR: Create `TestCase::testCreateTempFilePath()`.
- [x] PR: Create models: `Queue\*`.
- [x] PR: Create `exec:queue` command.
- [x] Implement `--drall-workers=n` in `exec:shell` and `exec:drush` commands.
- [x] Ensure proper test coverage.
- [x] Update README