### PR TITLE
Create ExecRunner which captures output

### DIFF
--- a/src/Runners/ExecRunner.php
+++ b/src/Runners/ExecRunner.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drall\Runners;
+
+/**
+ * A runner that uses PHP's exec() to execute commands.
+ */
+class ExecRunner implements RunnerInterface {
+
+  protected ?array $output;
+
+  public function __construct() {
+    $this->output = NULL;
+  }
+
+  public function execute(string $command): int {
+    $this->output = [];
+    exec($command, $this->output, $exitCode);
+    return $exitCode;
+  }
+
+  public function getOutput(): string {
+    return implode(PHP_EOL, $this->output) . PHP_EOL;
+  }
+
+}

--- a/src/Runners/FakeRunner.php
+++ b/src/Runners/FakeRunner.php
@@ -16,6 +16,10 @@ class FakeRunner implements RunnerInterface {
     return $this->exitCode;
   }
 
+  public function getOutput(): ?string {
+    return NULL;
+  }
+
   /**
    * Set the exit code to return for the next call to ::execute().
    *

--- a/src/Runners/PassthruRunner.php
+++ b/src/Runners/PassthruRunner.php
@@ -3,13 +3,17 @@
 namespace Drall\Runners;
 
 /**
- * A runner that uses PHP's passthru to execute commands.
+ * A runner that uses PHP's passthru() to execute commands.
  */
 class PassthruRunner implements RunnerInterface {
 
   public function execute(string $command): int {
     passthru($command, $exitCode);
     return $exitCode;
+  }
+
+  public function getOutput(): ?string {
+    return NULL;
   }
 
 }

--- a/src/Runners/RunnerInterface.php
+++ b/src/Runners/RunnerInterface.php
@@ -15,4 +15,12 @@ interface RunnerInterface {
    */
   public function execute(string $command): int;
 
+  /**
+   * Get output from the previous command, if supported.
+   *
+   * @return string|null
+   *   Output from the last executed command.
+   */
+  public function getOutput(): ?string;
+
 }

--- a/test/Unit/Runners/ExecRunnerTest.php
+++ b/test/Unit/Runners/ExecRunnerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Drall\Runners\ExecRunner;
+use Drall\TestCase;
+
+/**
+ * @covers \Drall\Runners\ExecRunner
+ */
+class ExecRunnerTest extends TestCase {
+
+  public function testExecute() {
+    $runner = new ExecRunner();
+    $this->assertEquals(0, $runner->execute('echo "Cowabunga!"'));
+  }
+
+  public function testGetOutput() {
+    $runner = new ExecRunner();
+    $runner->execute('echo "Cowabunga!"');
+    $this->assertEquals(
+      "Cowabunga!\n",
+      $runner->getOutput()
+    );
+  }
+
+}

--- a/test/Unit/Runners/PassthruRunnerTest.php
+++ b/test/Unit/Runners/PassthruRunnerTest.php
@@ -13,4 +13,10 @@ class PassthruRunnerTest extends TestCase {
     $this->assertEquals(0, $runner->execute('ls > /dev/null'));
   }
 
+  public function testGetOutput() {
+    $runner = new PassthruRunner();
+    $runner->execute('ls > /dev/null');
+    $this->assertNull($runner->getOutput());
+  }
+
 }


### PR DESCRIPTION
## What's done

- Creates an `ExecRunner` which can capture output and exit code using PHP's `exec()` function.
- Adds method `RunnerInterface::getOutput()`.