### PR TITLE
Create options: --drall-verbose and --drall-debug

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -27,6 +27,20 @@ abstract class BaseCommand extends Command {
       InputOption::VALUE_OPTIONAL,
       'Site group identifier.'
     );
+
+    $this->addOption(
+      'drall-verbose',
+      NULL,
+      InputOption::VALUE_NONE,
+      'Display verbose output.'
+    );
+
+    $this->addOption(
+      'drall-debug',
+      NULL,
+      InputOption::VALUE_NONE,
+      'Display debugging output.'
+    );
   }
 
   /**

--- a/src/Drall.php
+++ b/src/Drall.php
@@ -15,6 +15,7 @@ use DrupalFinder\DrupalFinder;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -69,6 +70,29 @@ final class Drall extends Application {
     $cmd->setSiteDetector($siteDetector);
     $cmd->setLogger($this->logger);
     $this->add($cmd);
+  }
+
+  protected function configureIO(InputInterface $input, OutputInterface $output) {
+    parent::configureIO($input, $output);
+
+    if ($input->hasParameterOption('--drall-debug', TRUE)) {
+      $output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
+    }
+    elseif ($input->hasParameterOption('--drall-verbose', TRUE)) {
+      $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
+    }
+    else {
+      $output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
+    }
+  }
+
+  protected function getDefaultInputDefinition(): InputDefinition {
+    $definition = parent::getDefaultInputDefinition();
+    $options = $definition->getOptions();
+    unset($options['verbose'], $options['quiet']);
+    $definition->setOptions($options);
+
+    return $definition;
   }
 
   private function createDefaultSiteDetector(string $root): SiteDetector {


### PR DESCRIPTION
This ensures that Drall's verbosity doesn't conflict with Drush.

Closes #38