### PR TITLE
Prepare logger in Command::beforeExecute()

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -3,10 +3,12 @@
 namespace Drall\Commands;
 
 use Drall\Traits\SiteDetectorAwareTrait;
+use DrupalCodeGenerator\Logger\ConsoleLogger;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class BaseCommand extends Command {
 
@@ -58,6 +60,12 @@ abstract class BaseCommand extends Command {
     }
 
     return getenv('DRALL_GROUP') ?: NULL;
+  }
+
+  protected function preExecute(InputInterface $input, OutputInterface $output) {
+    if (!$this->logger) {
+      $this->logger = new ConsoleLogger($output);
+    }
   }
 
 }

--- a/src/Commands/ExecDrushCommand.php
+++ b/src/Commands/ExecDrushCommand.php
@@ -24,6 +24,8 @@ class ExecDrushCommand extends BaseExecCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
+    $this->preExecute($input, $output);
+
     // Symfony Console only recognizes options that are defined in the
     // ::configure() method. Since our goal is to catch all arguments and
     // options and send them to drush, we do it ourselves using $argv.

--- a/src/Commands/ExecShellCommand.php
+++ b/src/Commands/ExecShellCommand.php
@@ -22,6 +22,8 @@ class ExecShellCommand extends BaseExecCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
+    $this->preExecute($input, $output);
+
     // Symfony Console only recognizes options that are defined in the
     // ::configure() method. Since our goal is to catch all arguments and
     // options and send them to drush, we do it ourselves using $argv.

--- a/src/Commands/SiteAliasesCommand.php
+++ b/src/Commands/SiteAliasesCommand.php
@@ -21,6 +21,8 @@ class SiteAliasesCommand extends BaseCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->preExecute($input, $output);
+
     $aliases = $this->siteDetector()
       ->getSiteAliases($this->getDrallGroup($input));
 

--- a/src/Commands/SiteDirectoriesCommand.php
+++ b/src/Commands/SiteDirectoriesCommand.php
@@ -21,6 +21,8 @@ class SiteDirectoriesCommand extends BaseCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->preExecute($input, $output);
+
     $dirNames = $this->siteDetector()
       ->getSiteDirNames($this->getDrallGroup($input));
 

--- a/src/Drall.php
+++ b/src/Drall.php
@@ -9,15 +9,12 @@ use Drall\Commands\SiteDirectoriesCommand;
 use Drall\Commands\SiteAliasesCommand;
 use Drall\Services\SiteDetector;
 use Drall\Traits\SiteDetectorAwareTrait;
-use DrupalCodeGenerator\Logger\ConsoleLogger;
 use Drush\SiteAlias\SiteAliasFileLoader;
 use DrupalFinder\DrupalFinder;
-use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class Drall extends Application {
@@ -26,7 +23,6 @@ final class Drall extends Application {
 
   const VERSION = '2.0.0-rc1';
 
-  use LoggerAwareTrait;
   use SiteDetectorAwareTrait;
 
   /**
@@ -34,18 +30,14 @@ final class Drall extends Application {
    */
   public function __construct(
     SiteDetector $siteDetector = NULL,
-    ?InputInterface $input = NULL,
-    ?OutputInterface $output = NULL
+    ?InputInterface $input = NULL
   ) {
     parent::__construct();
 
     $input = $input ?? new ArgvInput();
-    $output = $output ?? new ConsoleOutput();
 
     $this->setName(self::NAME);
     $this->setVersion(self::VERSION);
-    $this->configureIO($input, $output);
-    $this->setLogger(new ConsoleLogger($output));
 
     $root = $input->getParameterOption('--root') ?: getcwd();
     $siteDetector ??= $this->createDefaultSiteDetector($root);
@@ -53,22 +45,18 @@ final class Drall extends Application {
 
     $cmd = new SiteDirectoriesCommand();
     $cmd->setSiteDetector($siteDetector);
-    $cmd->setLogger($this->logger);
     $this->add($cmd);
 
     $cmd = new SiteAliasesCommand();
     $cmd->setSiteDetector($siteDetector);
-    $cmd->setLogger($this->logger);
     $this->add($cmd);
 
     $cmd = new ExecDrushCommand();
     $cmd->setSiteDetector($siteDetector);
-    $cmd->setLogger($this->logger);
     $this->add($cmd);
 
     $cmd = new ExecShellCommand();
     $cmd->setSiteDetector($siteDetector);
-    $cmd->setLogger($this->logger);
     $this->add($cmd);
   }
 

--- a/test/Unit/Commands/BaseExecCommandTest.php
+++ b/test/Unit/Commands/BaseExecCommandTest.php
@@ -2,7 +2,6 @@
 
 use Consolidation\SiteAlias\SiteAliasManager;
 use Drall\Runners\FakeRunner;
-use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 use DrupalFinder\DrupalFinder;
 use Drall\Drall;
@@ -28,8 +27,7 @@ class BaseExecCommandTest extends TestCase {
       ->method('getSiteDirNames')
       ->willReturn([]);
 
-    $output = new BufferedOutput();
-    $app = new Drall($siteDetectorMock, NULL, $output);
+    $app = new Drall($siteDetectorMock);
     $input = ['cmd' => 'cat @@uri'];
     $command = $app->find('exec:shell')
       ->setArgv(self::arrayInputAsArgv($input));
@@ -38,8 +36,8 @@ class BaseExecCommandTest extends TestCase {
 
     $tester->assertCommandIsSuccessful();
     $this->assertEquals(
-      "[warning] No Drupal sites found.\n",
-      $output->fetch(),
+      '[warning] No Drupal sites found.' . PHP_EOL,
+      $tester->getDisplay(),
     );
   }
 
@@ -77,8 +75,7 @@ class BaseExecCommandTest extends TestCase {
   }
 
   public function testExecuteWithoutPlaceholders() {
-    $output = new BufferedOutput();
-    $app = new Drall(NULL, NULL, $output);
+    $app = new Drall();
     $input = ['cmd' => 'drush core:status'];
     /** @var ExecCommand $command */
     $command = $app->find('exec:shell')
@@ -88,12 +85,12 @@ class BaseExecCommandTest extends TestCase {
     $this->assertEquals(1, $tester->execute($input));
     $this->assertEquals(
       '[error] The command has no placeholders and it can be run without Drall.' . PHP_EOL,
-    $output->fetch());
+      $tester->getDisplay()
+    );
   }
 
   public function testExecuteWithMixedPlaceholders() {
-    $output = new BufferedOutput();
-    $app = new Drall(NULL, NULL, $output);
+    $app = new Drall();
     $input = ['cmd' => 'drush @@site.local core:status && drush --uri=@@uri core:status'];
     /** @var ExecCommand $command */
     $command = $app->find('exec:shell')
@@ -103,7 +100,8 @@ class BaseExecCommandTest extends TestCase {
     $this->assertEquals(1, $tester->execute($input));
     $this->assertEquals(
       '[error] The command cannot contain both @@uri and @@site placeholders.' . PHP_EOL,
-    $output->fetch());
+      $tester->getDisplay()
+    );
   }
 
   /**

--- a/test/Unit/Commands/SiteAliasesCommandTest.php
+++ b/test/Unit/Commands/SiteAliasesCommandTest.php
@@ -80,14 +80,15 @@ EOF
 
     $output = new BufferedOutput();
 
-    $app = new Drall($siteDetectorMock, NULL, $output);
+    $app = new Drall($siteDetectorMock);
     $tester = new CommandTester($app->find('site:aliases'));
     $tester->execute([]);
 
     $tester->assertCommandIsSuccessful();
-
-    $this->assertEquals('', $tester->getDisplay());
-    $this->assertEquals("[warning] No site aliases found.\n", $output->fetch());
+    $this->assertEquals(
+      '[warning] No site aliases found.' . PHP_EOL,
+      $tester->getDisplay(TRUE)
+    );
   }
 
 }

--- a/test/Unit/Commands/SiteDirectoriesCommandTest.php
+++ b/test/Unit/Commands/SiteDirectoriesCommandTest.php
@@ -78,16 +78,16 @@ EOF
       ->method('getSiteDirNames')
       ->willReturn([]);
 
-    $output = new BufferedOutput();
-
-    $app = new Drall($siteDetectorMock, NULL, $output);
+    $app = new Drall($siteDetectorMock);
     $tester = new CommandTester($app->find('site:directories'));
     $tester->execute([]);
 
     $tester->assertCommandIsSuccessful();
 
-    $this->assertEquals('', $tester->getDisplay());
-    $this->assertEquals("[warning] No Drupal sites found.\n", $output->fetch());
+    $this->assertEquals(
+      '[warning] No Drupal sites found.' . PHP_EOL,
+      $tester->getDisplay()
+    );
   }
 
 }


### PR DESCRIPTION
This simplifies the tests as all output can be tested with `$tester->getDisplay()`.