### PR TITLE
Fix tests failing due to change in Drush output.

### DIFF
--- a/test/Integration/Commands/ExecDrushCommandTest.php
+++ b/test/Integration/Commands/ExecDrushCommandTest.php
@@ -16,15 +16,15 @@ class ExecDrushCommandTest extends IntegrationTestCase {
     $output = shell_exec('drall exec:drush st --fields=site');
     $this->assertOutputEquals(<<<EOF
 Current site: default
- Site path : sites/default
+Site path : sites/default
 Current site: donnie
- Site path : sites/donnie
+Site path : sites/donnie
 Current site: leo
- Site path : sites/leo
+Site path : sites/leo
 Current site: mikey
- Site path : sites/mikey
+Site path : sites/mikey
 Current site: ralph
- Site path : sites/ralph
+Site path : sites/ralph
 
 EOF, $output);
   }
@@ -36,9 +36,9 @@ EOF, $output);
     $output = shell_exec('drall exec:drush --drall-group=bluish core:status --uri=@@uri --fields=site');
     $this->assertOutputEquals(<<<EOF
 Current site: donnie
- Site path : sites/donnie
+Site path : sites/donnie
 Current site: leo
- Site path : sites/leo
+Site path : sites/leo
 
 EOF, $output);
   }
@@ -50,15 +50,15 @@ EOF, $output);
     $output = shell_exec('drall exec:drush st --uri=@@uri --fields=site');
     $this->assertOutputEquals(<<<EOF
 Current site: default
- Site path : sites/default
+Site path : sites/default
 Current site: donnie
- Site path : sites/donnie
+Site path : sites/donnie
 Current site: leo
- Site path : sites/leo
+Site path : sites/leo
 Current site: mikey
- Site path : sites/mikey
+Site path : sites/mikey
 Current site: ralph
- Site path : sites/ralph
+Site path : sites/ralph
 
 EOF, $output);
   }
@@ -70,15 +70,15 @@ EOF, $output);
     $output = shell_exec('drall exec:drush @@site.local st --fields=site');
     $this->assertOutputEquals(<<<EOF
 Current site: @donnie
- Site path : sites/donnie
+Site path : sites/donnie
 Current site: @leo
- Site path : sites/leo
+Site path : sites/leo
 Current site: @mikey
- Site path : sites/mikey
+Site path : sites/mikey
 Current site: @ralph
- Site path : sites/ralph
+Site path : sites/ralph
 Current site: @tmnt
- Site path : sites/default
+Site path : sites/default
 
 EOF, $output);
   }
@@ -90,9 +90,9 @@ EOF, $output);
     $output = shell_exec('drall exec:drush --drall-group=bluish @@site.local st --fields=site');
     $this->assertOutputEquals(<<<EOF
 Current site: @donnie
- Site path : sites/donnie
+Site path : sites/donnie
 Current site: @leo
- Site path : sites/leo
+Site path : sites/leo
 
 EOF, $output);
   }

--- a/test/Integration/Commands/ExecShellCommandTest.php
+++ b/test/Integration/Commands/ExecShellCommandTest.php
@@ -77,15 +77,15 @@ EOF, $output);
     $output = shell_exec('drall exec:shell drush @@site.local core:status --fields=site');
     $this->assertOutputEquals(<<<EOF
 Current site: @donnie
- Site path : sites/donnie
+Site path : sites/donnie
 Current site: @leo
- Site path : sites/leo
+Site path : sites/leo
 Current site: @mikey
- Site path : sites/mikey
+Site path : sites/mikey
 Current site: @ralph
- Site path : sites/ralph
+Site path : sites/ralph
 Current site: @tmnt
- Site path : sites/default
+Site path : sites/default
 
 EOF, $output);
   }
@@ -94,9 +94,9 @@ EOF, $output);
     $output = shell_exec('drall exec:shell drush --drall-group=bluish @@site.local st --fields=site');
     $this->assertOutputEquals(<<<EOF
 Current site: @donnie
- Site path : sites/donnie
+Site path : sites/donnie
 Current site: @leo
- Site path : sites/leo
+Site path : sites/leo
 
 EOF, $output);
   }


### PR DESCRIPTION
There used to be an extra space in front of certain Drush output but now that space is gone. This PR updates the expected output to match the new Drush output which fixes the tests.