### PR TITLE
Fix: GitHub Workflow always fails with Makefile (2)

### DIFF
--- a/.docker/main/Dockerfile
+++ b/.docker/main/Dockerfile
@@ -6,7 +6,7 @@ ENV PHP_INI_PATH="$PHP_INI_DIR/conf.d/php.ini"
 ENV DRUPAL_PATH="/opt/drupal"
 
 RUN apt-get update && \
-	apt-get install -qy mariadb-client git unzip
+	apt-get install -qy git make mariadb-client unzip
 
 RUN cp "$PHP_INI_DIR/php.ini-development" "$PHP_INI_PATH" \
     && pear config-set php_ini "$PHP_INI_PATH" \

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -24,8 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Prepare
         run: |
-          docker compose build -q
-          docker compose up -d
+          docker compose up -d --build --quiet-pull
           docker compose exec -T main make provision
       - name: Test
         run: docker compose exec -T --workdir=/opt/drall -e XDEBUG_MODE=coverage main make test

--- a/Makefile
+++ b/Makefile
@@ -4,27 +4,24 @@ ssh:
 
 
 .PHONY: provision
-provision:
-	@make provision/drall
-	@make provision/drupal
+provision: provision/drall provision/drupal
 
 
 .PHONY: provision/drupal
 provision/drupal:
-	cd /opt/drupal
+	mkdir -p /opt/drupal/web/sites/donnie
+	mkdir -p /opt/drupal/web/sites/leo
+	mkdir -p /opt/drupal/web/sites/mikey
+	mkdir -p /opt/drupal/web/sites/ralph
 
-	composer install
+	cp /opt/drupal/web/sites/default/default.settings.php /opt/drupal/web/sites/default/settings.php
+	cp /opt/drupal/web/sites/default/default.settings.php /opt/drupal/web/sites/donnie/settings.php
+	cp /opt/drupal/web/sites/default/default.settings.php /opt/drupal/web/sites/leo/settings.php
+	cp /opt/drupal/web/sites/default/default.settings.php /opt/drupal/web/sites/mikey/settings.php
+	cp /opt/drupal/web/sites/default/default.settings.php /opt/drupal/web/sites/ralph/settings.php
 
-	mkdir -p web/sites/donnie
-	mkdir -p web/sites/leo
-	mkdir -p web/sites/mikey
-	mkdir -p web/sites/ralph
-
-	cp web/sites/default/default.settings.php web/sites/default/settings.php
-	cp web/sites/default/default.settings.php web/sites/donnie/settings.php
-	cp web/sites/default/default.settings.php web/sites/leo/settings.php
-	cp web/sites/default/default.settings.php web/sites/mikey/settings.php
-	cp web/sites/default/default.settings.php web/sites/ralph/settings.php
+	rm -Rf /opt/drupal/composer.lock
+	composer --working-dir=/opt/drupal install --no-progress
 
 	@echo 'Drupal databases can be provisioned with: make provision/drupal/database'
 

--- a/src/Drall.php
+++ b/src/Drall.php
@@ -22,7 +22,7 @@ final class Drall extends Application {
 
   const NAME = 'Drall';
 
-  const VERSION = '2.0.0-rc1';
+  const VERSION = '2.0.0';
 
   use SiteDetectorAwareTrait;
 


### PR DESCRIPTION
- Fix: Version string was wrong in `Drall.php`
- Install latest `make` during container build
- Minor improvements to `Makefile` and `validation.yml`