### PR TITLE
Install jigarius/drall inside Drupal project

### DIFF
--- a/.docker/main/Dockerfile
+++ b/.docker/main/Dockerfile
@@ -1,6 +1,6 @@
 FROM drupal:9-php8.1-apache
 
-ENV PATH="/opt/drall/bin:${PATH}:/opt/drall/vendor/bin"
+ENV PATH="${PATH}:/opt/drall/vendor/bin"
 ENV PHP_INI_PATH="$PHP_INI_DIR/conf.d/php.ini"
 ENV DRUPAL_PATH="/opt/drupal"
 

--- a/.docker/main/composer.json
+++ b/.docker/main/composer.json
@@ -12,6 +12,13 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        {
+            "type": "path",
+            "url": "/opt/drall",
+            "options": {
+                "symlink": true
+            }
         }
     ],
     "require": {
@@ -19,7 +26,8 @@
         "drupal/core-composer-scaffold": "*",
         "drupal/core-recommended": "^9",
         "drupal/core-vendor-hardening": "*",
-        "drush/drush": "*"
+        "drush/drush": "*",
+        "jigarius/drall": "*"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
Since Drall reads Drush aliases just like Drush does, it should be installed locally within the project. This pull request installs Drall as a composer package within the Drupal site that is used for demonstrating Drall usage.