### PR TITLE
Improve output formatting and verbosity

### DIFF
--- a/bin/drall
+++ b/bin/drall
@@ -24,13 +24,6 @@ foreach ([
 
 use Drall\Drall;
 
-try {
-  $drall = new Drall();
-  $exitCode = $drall->run();
-}
-catch (Exception $e) {
-  echo "ERROR {$e->getCode()}: {$e->getMessage()}";
-  exit(1);
-}
-
-exit($exitCode);
+$drall = new Drall();
+$drall->setAutoExit(TRUE);
+$drall->run();

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -78,11 +78,11 @@ abstract class BaseCommand extends Command {
     }
 
     if ($group = $this->getDrallGroup($input)) {
-      $this->logger->debug('Detected group: {group}', ['group' => $group]);
+      $this->logger->info('Using group: {group}', ['group' => $group]);
     }
 
     if ($filter = $this->getDrallFilter($input)) {
-      $this->logger->debug('Detected filter: {filter}', ['filter' => $filter]);
+      $this->logger->info('Using filter: {filter}', ['filter' => $filter]);
     }
   }
 

--- a/src/Command/ExecCommand.php
+++ b/src/Command/ExecCommand.php
@@ -12,6 +12,7 @@ use Drall\Drall;
 use Drall\Model\EnvironmentId;
 use Drall\Model\Placeholder;
 use Drall\Trait\SignalAwareTrait;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -91,15 +92,38 @@ final class ExecCommand extends BaseCommand {
   }
 
   protected function initialize(InputInterface $input, OutputInterface $output): void {
+    if (!method_exists($input, 'getRawTokens')) {
+      parent::initialize($input, $output);
+      return;
+    }
+
+    // Parts of the command after "exec".
+    $rawTokens = $input->getRawTokens(TRUE);
+
     // If obsolete --drall-* options are present, then abort.
-    if (method_exists($input, 'getRawTokens')) {
-      foreach ($input->getRawTokens() as $token) {
-        if (str_starts_with($token, '--drall-')) {
-          $output->writeln(<<<EOT
+    foreach ($rawTokens as $token) {
+      if (str_starts_with($token, '--drall-')) {
+        $output->writeln(<<<EOT
 In Drall 4.x, all --drall-* options have been renamed.
 See https://github.com/jigarius/drall/issues/99
 EOT);
-          throw new \RuntimeException('Obsolete options detected.');
+        throw new \RuntimeException('Obsolete options detected');
+      }
+    }
+
+    // If options are present, an options separator (--) is required.
+    if (!in_array('--', $rawTokens)) {
+      foreach ($rawTokens as $token) {
+        if (str_starts_with($token, '-')) {
+          $output->writeln(<<<EOT
+When using options, a "--" must be placed before the command to be executed.
+
+<comment>Incorrect:</comment> drall exec --dry-run drush --field=site core:status
+<comment>Correct:</comment>   drall exec --dry-run -- drush --field=site core:status
+
+Notice the `--` between `--dry-run` and the word `drush`.
+EOT);
+          throw new \RuntimeException('Missing options separator');
         }
       }
     }
@@ -140,19 +164,19 @@ EOT);
     // Display commands without executing them.
     if ($input->getOption('dry-run')) {
       foreach ($values as $value) {
-        $sCommand = Placeholder::replace([$placeholder->value => $value], $command);
-        $output->writeln("# Item: $value", OutputInterface::VERBOSITY_VERBOSE);
-        $output->writeln($sCommand);
+        $pCommand = Placeholder::replace([$placeholder->value => $value], $command);
+        $output->writeln("• $value: Preview");
+        $output->writeln($pCommand, OutputInterface::VERBOSITY_QUIET);
       }
 
-      return 0;
+      return Command::SUCCESS;
     }
 
     $progressBar = new ProgressBar(
       $this->isProgressBarHidden($input) ? new NullOutput() : $output,
       count($values)
     );
-    $exitCode = 0;
+    $exitCode = Command::SUCCESS;
 
     // Handle interruption signals to stop Drall gracefully.
     $isStopping = FALSE;
@@ -162,7 +186,7 @@ EOT);
       // If a previous SIGINT was received, then stop immediately.
       if ($isStopping) {
         $this->logger->error('Interrupted by user.');
-        exit(1);
+        exit(Command::FAILURE);
       }
 
       // Prepare to stop after the current item is processed.
@@ -194,14 +218,22 @@ EOT);
           yield $process->start();
           $this->logger->debug('Running: {command}', ['command' => $sCommand]);
 
-          $sOutput = yield ByteStream\buffer($process->getStdout());
-          if (0 !== yield $process->join()) {
-            $exitCode = 1;
+          // @todo Improve formatting of headings.
+          $pOutput = yield ByteStream\buffer($process->getStdout());
+          $pStatus = 'Done';
+          $pIcon = '✔';
+          if (Command::SUCCESS !== yield $process->join()) {
+            $pStatus = 'Failed';
+            $pIcon = '✖';
+            $exitCode = Command::FAILURE;
           }
 
+          $pMessage = "$pIcon $value: $pStatus";
+
           $progressBar->clear();
-          $output->writeln("Finished: $value");
-          $output->write($sOutput);
+          // Always display command output, even in --quiet mode.
+          $output->writeln($pMessage, OutputInterface::VERBOSITY_QUIET);
+          $output->write($pOutput);
 
           $progressBar->advance();
           $progressBar->display();
@@ -217,7 +249,7 @@ EOT);
 
     if ($isStopping) {
       $this->logger->error('Interrupted by user.');
-      return 1;
+      return Command::FAILURE;
     }
 
     return $exitCode;
@@ -241,29 +273,10 @@ EOT);
    * Output: drush st --fields=site
    */
   private function getCommand(InputInterface $input, OutputInterface $output): ?string {
-    $rawTokens = $input->getRawTokens(TRUE);
-    if (!in_array('--', $rawTokens)) {
-      foreach ($rawTokens as $token) {
-        if (str_starts_with($token, '-')) {
-          $output->writeln(<<<EOT
-When using options, a "--" must be placed before the command to be executed.
-
-<comment>Incorrect:</comment> drall exec --dry-run drush --field=site core:status
-<comment>Correct:</comment>   drall exec --dry-run -- drush --field=site core:status
-
-Notice the `--` between `--dry-run` and the word `drush`.
-EOT);
-          $this->logger->error('Separator "--" must be used when using options.');
-          return NULL;
-        }
-      }
-    }
-
-    // @todo Throw an error if --drall-* options are present.
     // Everything after the first "--" is treated as an argument. All such
     // arguments are treated as parts of the command to be executed.
     $command = implode(' ', $input->getArguments()['cmd']);
-    $this->logger->debug("Command: {command}", ['command' => $command]);
+    $this->logger->debug("Command received: {command}", ['command' => $command]);
 
     if (
       str_contains($command, 'drush') &&
@@ -272,6 +285,7 @@ EOT);
       // Inject --uri=@@dir for Drush commands without placeholders.
       $command = preg_replace('/\b(drush) /', 'drush --uri=@@dir ', $command, -1);
       $this->logger->debug('Injected --uri parameter for Drush command.');
+      $this->logger->notice("Command modified: {command}", ['command' => $command]);
     }
 
     return $command;

--- a/src/Drall.php
+++ b/src/Drall.php
@@ -42,14 +42,11 @@ final class Drall extends Application {
   protected function configureIO(InputInterface $input, OutputInterface $output): void {
     parent::configureIO($input, $output);
 
-    if ($input->hasParameterOption('--debug', TRUE)) {
+    if (
+      $input->hasParameterOption('--debug', TRUE) ||
+      $input->hasParameterOption('-d', TRUE)
+    ) {
       $output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
-    }
-    elseif ($input->hasParameterOption('--verbose', TRUE)) {
-      $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
-    }
-    else {
-      $output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
     }
 
     // The parent::configureIO sets verbosity in a SHELL_VERBOSITY. This causes
@@ -69,7 +66,6 @@ final class Drall extends Application {
     // Remove unneeded options.
     $options = $definition->getOptions();
     unset(
-      $options['quiet'],
       $options['no-interaction'],
     );
     $definition->setOptions($options);

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -21,6 +21,19 @@ abstract class TestCase extends TestCaseBase {
   const PATH_EMPTY_DRUPAL = '/opt/empty-drupal';
 
   /**
+   * Normalizes console output by stripping unimportant spaces.
+   *
+   * @param string $output
+   *   Raw output.
+   *
+   * @return string
+   *   Normalized output.
+   */
+  private static function normalizeString(string $output): string {
+    return preg_replace('@(\s+)\n@', "\n", $output);
+  }
+
+  /**
    * Creates a temporary file path.
    *
    * @example
@@ -57,19 +70,16 @@ abstract class TestCase extends TestCaseBase {
     return $drupalFinder;
   }
 
-  /**
-   * Asserts Shell output ignoring unimportant whitespace.
-   *
-   * @param string $expected
-   *   Expected output.
-   * @param mixed $actual
-   *   Actual output.
-   * @param string $message
-   *   Error message.
-   */
   protected function assertOutputEquals(string $expected, mixed $actual, string $message = ''): void {
-    $actual = preg_replace('@(\s+)\n@', "\n", $actual ?? '');
-    $this->assertEquals($expected, $actual, $message);
+    $this->assertEquals($expected, self::normalizeString($actual ?? ''), $message);
+  }
+
+  protected function assertOutputStartsWith(string $expected, mixed $actual, string $message = ''): void {
+    $this->assertStringStartsWith($expected, self::normalizeString($actual ?? ''), $message);
+  }
+
+  protected function assertOutputContainsString(string $expected, mixed $actual, string $message = ''): void {
+    $this->assertStringContainsString($expected, self::normalizeString($actual ?? ''), $message);
   }
 
 }

--- a/test/Integration/Command/BaseCommandTest.php
+++ b/test/Integration/Command/BaseCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drall\Integration\Command;
+
+use Drall\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * @testdox Base Command
+ * @covers \Drall\Command\BaseCommand
+ */
+class BaseCommandTest extends TestCase {
+
+  /**
+   * @testdox Detects --group.
+   */
+  public function testWithGroup(): void {
+    $process1 = Process::fromShellCommandline(
+      'drall exec --group=bluish --dry-run -vv -- ./vendor/bin/drush st',
+      static::PATH_DRUPAL,
+    );
+    $process1->run();
+    $this->assertOutputStartsWith(<<<EOT
+[info] Using group: bluish
+EOT, $process1->getOutput());
+
+    // Short form.
+    $process1 = Process::fromShellCommandline(
+      'drall exec -g bluish --dry-run -vv -- ./vendor/bin/drush st',
+      static::PATH_DRUPAL,
+    );
+    $process1->run();
+    $this->assertOutputStartsWith(<<<EOT
+[info] Using group: bluish
+EOT, $process1->getOutput());
+  }
+
+  /**
+   * @testdox Detects --filter.
+   */
+  public function testWithFilter(): void {
+    $process1 = Process::fromShellCommandline(
+      'drall exec --filter=leo --dry-run -vv -- ./vendor/bin/drush st',
+      static::PATH_DRUPAL,
+    );
+    $process1->run();
+    $this->assertOutputStartsWith(<<<EOT
+[info] Using filter: leo
+EOT, $process1->getOutput());
+
+    // Short form.
+    $process2 = Process::fromShellCommandline(
+      'drall exec -f leo --dry-run -vv -- ./vendor/bin/drush st',
+      static::PATH_DRUPAL,
+    );
+    $process2->run();
+    $this->assertOutputStartsWith(<<<EOT
+[info] Using filter: leo
+EOT, $process2->getOutput());
+  }
+
+}

--- a/test/Integration/Command/ExecCommandTest.php
+++ b/test/Integration/Command/ExecCommandTest.php
@@ -12,53 +12,21 @@ use Symfony\Component\Process\Process;
 class ExecCommandTest extends TestCase {
 
   /**
-   * @testdox Detects commands correctly.
-   */
-  public function testCommandDetection() {
-    $process = Process::fromShellCommandline(
-      'drall exec --debug --dry-run -- drush st',
-      static::PATH_DRUPAL,
-    );
-    $process->run();
-    $this->assertEquals(<<<EOT
-[debug] Command: drush st
-[debug] Injected --uri parameter for Drush command.
-# Item: default
-drush --uri=default st
-# Item: donnie
-drush --uri=donnie st
-# Item: leo
-drush --uri=leo st
-# Item: mikey
-drush --uri=mikey st
-# Item: ralph
-drush --uri=ralph st
-
-EOT, $process->getOutput());
-  }
-
-  /**
    * @testdox Works when -- is absent and options are not used.
    */
-  public function testMissingArgsSeparatorWithNoOptions(): void {
+  public function testMissingOptionsSeparatorWithNoOptions(): void {
     $process = Process::fromShellCommandline(
-      'drall exec --dry-run drush st',
+      'drall exec ./vendor/bin/drush st',
       static::PATH_DRUPAL,
     );
     $process->run();
-    $this->assertOutputEquals(<<<EOT
-When using options, a "--" must be placed before the command to be executed.
-Incorrect: drall exec --dry-run drush --field=site core:status
-Correct:   drall exec --dry-run -- drush --field=site core:status
-Notice the `--` between `--dry-run` and the word `drush`.
-
-EOT, $process->getOutput());
+    $this->assertEquals(0, $process->getExitCode());
   }
 
   /**
    * @testdox Shows error when -- is absent but options are used.
    */
-  public function testMissingArgsSeparatorWithOptions(): void {
+  public function testMissingOptionsSeparatorWithOptions(): void {
     $process = Process::fromShellCommandline(
       'drall exec --dry-run drush st',
     static::PATH_DRUPAL,
@@ -71,6 +39,23 @@ Correct:   drall exec --dry-run -- drush --field=site core:status
 Notice the `--` between `--dry-run` and the word `drush`.
 
 EOT, $process->getOutput());
+    $this->assertOutputContainsString('Missing options separator', $process->getErrorOutput());
+    $this->assertEquals(1, $process->getExitCode());
+  }
+
+  /**
+   * @testdox Shows error when --drall-* options are detected.
+   */
+  public function testShowErrorForObsoleteOptions(): void {
+    $process = Process::fromShellCommandline('./vendor/bin/drall exec --drall-foo drush st', static::PATH_DRUPAL);
+    $process->run();
+    $this->assertOutputEquals(<<<EOT
+In Drall 4.x, all --drall-* options have been renamed.
+See https://github.com/jigarius/drall/issues/99
+
+EOT, $process->getOutput());
+    $this->assertOutputContainsString('Obsolete options detected', $process->getErrorOutput());
+    $this->assertEquals(1, $process->getExitCode());
   }
 
   /**
@@ -133,7 +118,7 @@ EOT, $process->getOutput());
     );
     $process->run();
     $this->assertOutputEquals(<<<EOT
-Finished: @tmnt
+✔ @tmnt: Done
 Site: @tmnt
 /opt/drupal
 
@@ -150,15 +135,15 @@ EOT, $process->getOutput());
     );
     $process->run();
     $this->assertOutputEquals(<<<EOF
-Finished: default
+✔ default: Done
 sites/default
-Finished: donnie
+✔ donnie: Done
 sites/donnie
-Finished: leo
+✔ leo: Done
 sites/leo
-Finished: mikey
+✔ mikey: Done
 sites/mikey
-Finished: ralph
+✔ ralph: Done
 sites/ralph
 
 EOF, $process->getOutput());
@@ -174,15 +159,15 @@ EOF, $process->getOutput());
     );
     $process->run();
     $this->assertOutputEquals(<<<EOF
-Finished: @donnie
+✔ @donnie: Done
 sites/donnie
-Finished: @leo
+✔ @leo: Done
 sites/leo
-Finished: @mikey
+✔ @mikey: Done
 sites/mikey
-Finished: @ralph
+✔ @ralph: Done
 sites/ralph
-Finished: @tmnt
+✔ @tmnt: Done
 sites/default
 
 EOF, $process->getOutput());
@@ -198,15 +183,15 @@ EOF, $process->getOutput());
     );
     $process->run();
     $this->assertOutputEquals(<<<EOF
-Finished: default
+✔ default: Done
 sites/default
-Finished: donnie
+✔ donnie: Done
 sites/donnie
-Finished: leo
+✔ leo: Done
 sites/leo
-Finished: mikey
+✔ mikey: Done
 sites/mikey
-Finished: ralph
+✔ ralph: Done
 sites/ralph
 
 EOF, $process->getOutput());
@@ -222,19 +207,19 @@ EOF, $process->getOutput());
     );
     $process->run();
     $this->assertOutputEquals(<<<EOF
-Finished: default
+✔ default: Done
 Site path : sites/default
 Site URI : http://default
-Finished: donnie
+✔ donnie: Done
 Site path : sites/donnie
 Site URI : http://donnie
-Finished: leo
+✔ leo: Done
 Site path : sites/leo
 Site URI : http://leo
-Finished: mikey
+✔ mikey: Done
 Site path : sites/mikey
 Site URI : http://mikey
-Finished: ralph
+✔ ralph: Done
 Site path : sites/ralph
 Site URI : http://ralph
 
@@ -269,19 +254,19 @@ EOF, $process->getOutput());
     );
     $process->run();
     $this->assertOutputEquals(<<<EOF
-Finished: default
+✔ default: Done
 Drush status
 Site path : sites/default
-Finished: donnie
+✔ donnie: Done
 Drush status
 Site path : sites/donnie
-Finished: leo
+✔ leo: Done
 Drush status
 Site path : sites/leo
-Finished: mikey
+✔ mikey: Done
 Drush status
 Site path : sites/mikey
-Finished: ralph
+✔ ralph: Done
 Drush status
 Site path : sites/ralph
 
@@ -313,15 +298,15 @@ EOF, $process->getOutput());
     );
     $process->run();
     $this->assertOutputEquals(<<<EOF
-Finished: default
+✔ default: Done
 web/sites/default/settings.php
-Finished: donnie
+✔ donnie: Done
 web/sites/donnie/settings.php
-Finished: leo
+✔ leo: Done
 web/sites/leo/settings.php
-Finished: mikey
+✔ mikey: Done
 web/sites/mikey/settings.php
-Finished: ralph
+✔ ralph: Done
 web/sites/ralph/settings.php
 
 EOF, $process->getOutput());
@@ -337,7 +322,7 @@ EOF, $process->getOutput());
     );
     $process1->run();
     $this->assertOutputEquals(<<<EOF
-Finished: leo
+✔ leo: Done
 sites/leo
 
 EOF, $process1->getOutput());
@@ -349,7 +334,7 @@ EOF, $process1->getOutput());
     );
     $process2->run();
     $this->assertOutputEquals(<<<EOF
-Finished: leo
+✔ leo: Done
 sites/leo
 
 EOF, $process2->getOutput());
@@ -365,21 +350,21 @@ EOF, $process2->getOutput());
     );
     $process->run();
     $this->assertOutputEquals(<<<EOF
-[debug] Command: ls web/sites/@@dir/settings.php
+[debug] Command received: ls web/sites/@@dir/settings.php
 [debug] Running: ls web/sites/default/settings.php
-Finished: default
+✔ default: Done
 web/sites/default/settings.php
 [debug] Running: ls web/sites/donnie/settings.php
-Finished: donnie
+✔ donnie: Done
 web/sites/donnie/settings.php
 [debug] Running: ls web/sites/leo/settings.php
-Finished: leo
+✔ leo: Done
 web/sites/leo/settings.php
 [debug] Running: ls web/sites/mikey/settings.php
-Finished: mikey
+✔ mikey: Done
 web/sites/mikey/settings.php
 [debug] Running: ls web/sites/ralph/settings.php
-Finished: ralph
+✔ ralph: Done
 web/sites/ralph/settings.php
 
 EOF, $process->getOutput());
@@ -395,9 +380,9 @@ EOF, $process->getOutput());
     );
     $process1->run();
     $this->assertOutputEquals(<<<EOF
-Finished: donnie
+✔ donnie: Done
 sites/donnie
-Finished: leo
+✔ leo: Done
 sites/leo
 
 EOF, $process1->getOutput());
@@ -409,9 +394,9 @@ EOF, $process1->getOutput());
     );
     $process2->run();
     $this->assertOutputEquals(<<<EOF
-Finished: donnie
+✔ donnie: Done
 sites/donnie
-Finished: leo
+✔ leo: Done
 sites/leo
 
 EOF, $process2->getOutput());
@@ -428,9 +413,9 @@ EOF, $process2->getOutput());
     );
     $process->run();
     $this->assertOutputEquals(<<<EOF
-Finished: donnie
+✔ donnie: Done
 sites/donnie
-Finished: leo
+✔ leo: Done
 sites/leo
 
 EOF, $process->getOutput());
@@ -446,15 +431,15 @@ EOF, $process->getOutput());
     );
     $process->run();
     $this->assertOutputEquals(<<<EOF
-Finished: @donnie
+✔ @donnie: Done
 Site path : sites/donnie
-Finished: @leo
+✔ @leo: Done
 Site path : sites/leo
-Finished: @mikey
+✔ @mikey: Done
 Site path : sites/mikey
-Finished: @ralph
+✔ @ralph: Done
 Site path : sites/ralph
-Finished: @tmnt
+✔ @tmnt: Done
 Site path : sites/default
 
 EOF, $process->getOutput());
@@ -470,21 +455,21 @@ EOF, $process->getOutput());
     );
     $process->run();
     $this->assertOutputEquals(<<<EOF
-[debug] Command: ./vendor/bin/drush @@site.local st --fields=site
+[debug] Command received: ./vendor/bin/drush @@site.local st --fields=site
 [debug] Running: ./vendor/bin/drush @donnie.local st --fields=site
-Finished: @donnie
+✔ @donnie: Done
 Site path : sites/donnie
 [debug] Running: ./vendor/bin/drush @leo.local st --fields=site
-Finished: @leo
+✔ @leo: Done
 Site path : sites/leo
 [debug] Running: ./vendor/bin/drush @mikey.local st --fields=site
-Finished: @mikey
+✔ @mikey: Done
 Site path : sites/mikey
 [debug] Running: ./vendor/bin/drush @ralph.local st --fields=site
-Finished: @ralph
+✔ @ralph: Done
 Site path : sites/ralph
 [debug] Running: ./vendor/bin/drush @tmnt.local st --fields=site
-Finished: @tmnt
+✔ @tmnt: Done
 Site path : sites/default
 
 EOF, $process->getOutput());
@@ -500,9 +485,9 @@ EOF, $process->getOutput());
     );
     $process->run();
     $this->assertOutputEquals(<<<EOF
-Finished: @donnie
+✔ @donnie: Done
 sites/donnie
-Finished: @leo
+✔ @leo: Done
 sites/leo
 
 EOF, $process->getOutput());
@@ -522,7 +507,7 @@ EOF, $process->getOutput());
     $output = preg_replace('@(Drush version :) ([\d|\.|-]+)@', '$1 x.y.z', $process->getOutput());
 
     $this->assertOutputEquals(<<<EOF
-Finished: default
+✔ default: Done
  [info] Starting bootstrap to none
  [info] Drush bootstrap phase 0
  [info] Try to validate bootstrap phase 0
@@ -532,9 +517,9 @@ EOF, $output);
   }
 
   /**
-   * @testdox With progress bar.
+   * @testdox Progress bar.
    */
-  public function testWithProgressBarVisible(): void {
+  public function testWithProgressBar(): void {
     $process = Process::fromShellCommandline(
       'drall exec -- ./vendor/bin/drush st --field=site 2>&1',
       static::PATH_DRUPAL,
@@ -542,15 +527,15 @@ EOF, $output);
     );
     $process->run();
     $this->assertOutputEquals(<<<EOF
-Finished: default
+✔ default: Done
 sites/default
- 1/5 [=====>----------------------]  20%Finished: donnie
+ 1/5 [=====>----------------------]  20%✔ donnie: Done
 sites/donnie
- 2/5 [===========>----------------]  40%Finished: leo
+ 2/5 [===========>----------------]  40%✔ leo: Done
 sites/leo
- 3/5 [================>-----------]  60%Finished: mikey
+ 3/5 [================>-----------]  60%✔ mikey: Done
 sites/mikey
- 4/5 [======================>-----]  80%Finished: ralph
+ 4/5 [======================>-----]  80%✔ ralph: Done
 sites/ralph
  5/5 [============================] 100%
 
@@ -560,7 +545,7 @@ EOF, $process->getOutput());
   /**
    * @testdox With --no-progress.
    */
-  public function testWithProgressBarHidden(): void {
+  public function testWithNoProgressBar(): void {
     $process = Process::fromShellCommandline(
       'drall exec --no-progress -- ./vendor/bin/drush st --field=site 2>&1',
       static::PATH_DRUPAL,
@@ -572,18 +557,52 @@ EOF, $process->getOutput());
     );
     $process->run();
     $this->assertOutputEquals(<<<EOF
-Finished: default
+✔ default: Done
 sites/default
-Finished: donnie
+✔ donnie: Done
 sites/donnie
-Finished: leo
+✔ leo: Done
 sites/leo
-Finished: mikey
+✔ mikey: Done
 sites/mikey
-Finished: ralph
+✔ ralph: Done
 sites/ralph
 
 EOF, $process->getOutput());
+  }
+
+  /**
+   * @testdox With verbosity quiet.
+   */
+  public function testWithVerbosityQuiet(): void {
+    $process1 = Process::fromShellCommandline(
+      'drall exec --quiet -- ./vendor/bin/drush st --field=site',
+      static::PATH_DRUPAL,
+    );
+    $process1->run();
+    $this->assertEquals(<<<EOT
+✔ default: Done
+✔ donnie: Done
+✔ leo: Done
+✔ mikey: Done
+✔ ralph: Done
+
+EOT, $process1->getOutput());
+
+    // Short form.
+    $process2 = Process::fromShellCommandline(
+      'drall exec -q -- ./vendor/bin/drush st --field=site',
+      static::PATH_DRUPAL,
+    );
+    $process2->run();
+    $this->assertEquals(<<<EOT
+✔ default: Done
+✔ donnie: Done
+✔ leo: Done
+✔ mikey: Done
+✔ ralph: Done
+
+EOT, $process2->getOutput());
   }
 
   /**
@@ -596,10 +615,15 @@ EOF, $process->getOutput());
     );
     $process1->run();
     $this->assertOutputEquals(<<<EOF
+• default: Preview
 ./vendor/bin/drush --uri=default st
+• donnie: Preview
 ./vendor/bin/drush --uri=donnie st
+• leo: Preview
 ./vendor/bin/drush --uri=leo st
+• mikey: Preview
 ./vendor/bin/drush --uri=mikey st
+• ralph: Preview
 ./vendor/bin/drush --uri=ralph st
 
 EOF, $process1->getOutput());
@@ -611,35 +635,35 @@ EOF, $process1->getOutput());
     );
     $process2->run();
     $this->assertOutputEquals(<<<EOF
+• default: Preview
 ./vendor/bin/drush --uri=default st
+• donnie: Preview
 ./vendor/bin/drush --uri=donnie st
+• leo: Preview
 ./vendor/bin/drush --uri=leo st
+• mikey: Preview
 ./vendor/bin/drush --uri=mikey st
+• ralph: Preview
 ./vendor/bin/drush --uri=ralph st
 
 EOF, $process2->getOutput());
   }
 
   /**
-   * @testdox With --dry-run --verbose.
+   * @testdox With --dry-run --quiet.
    */
-  public function testWithDryRunVerbose(): void {
+  public function testWithDryRunQuiet(): void {
     $process = Process::fromShellCommandline(
-      'drall exec --dry-run --verbose -- drush st',
+      'drall exec --dry-run --quiet -- ./vendor/bin/drush st',
       static::PATH_DRUPAL,
     );
     $process->run();
     $this->assertOutputEquals(<<<EOF
-# Item: default
-drush --uri=default st
-# Item: donnie
-drush --uri=donnie st
-# Item: leo
-drush --uri=leo st
-# Item: mikey
-drush --uri=mikey st
-# Item: ralph
-drush --uri=ralph st
+./vendor/bin/drush --uri=default st
+./vendor/bin/drush --uri=donnie st
+./vendor/bin/drush --uri=leo st
+./vendor/bin/drush --uri=mikey st
+./vendor/bin/drush --uri=ralph st
 
 EOF, $process->getOutput());
   }
@@ -690,13 +714,26 @@ EOF, $process->getOutput());
   }
 
   /**
-   * @testdox Non-zero exit code.
+   * @testdox Exits with non-zero code if any command fails.
    */
   public function testNonZeroExitCode(): void {
     $process = Process::fromShellCommandline(
-      'drall exec --group=bad ./vendor/bin/drush st --field=site',
+      "drall ex -- \"if [ 'default' = '@@dir' ]; then exit 1; fi; echo 'Hello @@dir!';\"",
+      static::PATH_DRUPAL,
     );
     $process->run();
+    $this->assertOutputEquals(<<<EOT
+✖ default: Failed
+✔ donnie: Done
+Hello donnie!
+✔ leo: Done
+Hello leo!
+✔ mikey: Done
+Hello mikey!
+✔ ralph: Done
+Hello ralph!
+
+EOT, $process->getOutput());
     $this->assertEquals(1, $process->getExitCode());
   }
 

--- a/test/Integration/DrallTest.php
+++ b/test/Integration/DrallTest.php
@@ -38,18 +38,4 @@ class DrallTest extends TestCase {
 EOT, $process->getErrorOutput());
   }
 
-  /**
-   * @testdox Shows error when --drall-* options are detected.
-   */
-  public function testShowErrorForObsoleteOptions(): void {
-    $process = Process::fromShellCommandline('./vendor/bin/drall exec --drall-foo drush st', static::PATH_DRUPAL);
-    $process->run();
-    $this->assertOutputEquals(<<<EOT
-In Drall 4.x, all --drall-* options have been renamed.
-See https://github.com/jigarius/drall/issues/99
-
-EOT, $process->getOutput());
-    $this->assertEquals(1, $process->getExitCode());
-  }
-
 }

--- a/test/Unit/DrallTest.php
+++ b/test/Unit/DrallTest.php
@@ -17,12 +17,16 @@ class DrallTest extends TestCase {
     $this->assertSame(Drall::NAME, $app->getName());
   }
 
+  /**
+   * @testdox Default input options are defined.
+   */
   public function testDefaultInputOptions() {
     $app = new Drall();
     $options = $app->getDefinition()->getOptions();
 
     $this->assertEquals([
       'help',
+      'quiet',
       'verbose',
       'version',
       'ansi',
@@ -30,20 +34,69 @@ class DrallTest extends TestCase {
     ], array_keys($options));
   }
 
-  public function testOptionVerbosityNormal() {
+  /**
+   * @testdox Verbosity quiet.
+   */
+  public function testVerbosityQuiet() {
+    $tester = new ApplicationTester(new Drall());
+
+    $tester->run(['command' => 'version', '--quiet' => TRUE]);
+    $this->assertEquals(OutputInterface::VERBOSITY_QUIET, $tester->getOutput()->getVerbosity());
+
+    $tester->run(['command' => 'version', '-q' => TRUE]);
+    $this->assertEquals(OutputInterface::VERBOSITY_QUIET, $tester->getOutput()->getVerbosity());
+  }
+
+  /**
+   * @testdox Verbosity level 0.
+   */
+  public function testVerbosityNormal() {
     $tester = new ApplicationTester(new Drall());
     $tester->run(['command' => 'version']);
     $this->assertEquals(OutputInterface::VERBOSITY_NORMAL, $tester->getOutput()->getVerbosity());
   }
 
-  public function testOptionVerbosityVerbose() {
+  /**
+   * @testdox Verbosity level 1.
+   */
+  public function testVerbosityVerbose() {
     $tester = new ApplicationTester(new Drall());
+
     $tester->run(['command' => 'version', '--verbose' => TRUE]);
+    $this->assertEquals(OutputInterface::VERBOSITY_VERBOSE, $tester->getOutput()->getVerbosity());
+
+    $tester->run(['command' => 'version', '-v' => TRUE]);
+    $this->assertEquals(OutputInterface::VERBOSITY_VERBOSE, $tester->getOutput()->getVerbosity());
+  }
+
+  /**
+   * @testdox Verbosity level 2.
+   */
+  public function testVerbosityVeryVerbose() {
+    $tester = new ApplicationTester(new Drall());
+
+    $tester->run(['command' => 'version', '--verbose' => 2]);
+    $this->assertEquals(OutputInterface::VERBOSITY_VERY_VERBOSE, $tester->getOutput()->getVerbosity());
+
+    $tester->run(['command' => 'version', '-vv' => TRUE]);
     $this->assertEquals(OutputInterface::VERBOSITY_VERY_VERBOSE, $tester->getOutput()->getVerbosity());
   }
 
-  public function testOptionVerbosityDebug() {
+  /**
+   * @testdox Verbosity level 3.
+   */
+  public function testVerbosityDebug() {
     $tester = new ApplicationTester(new Drall());
+
+    $tester->run(['command' => 'version', '--verbose' => 3]);
+    $this->assertEquals(OutputInterface::VERBOSITY_DEBUG, $tester->getOutput()->getVerbosity());
+
+    $tester->run(['command' => 'version', '-vvv' => TRUE]);
+    $this->assertEquals(OutputInterface::VERBOSITY_DEBUG, $tester->getOutput()->getVerbosity());
+
+    $tester->run(['command' => 'version', '-d']);
+    $this->assertEquals(OutputInterface::VERBOSITY_DEBUG, $tester->getOutput()->getVerbosity());
+
     $tester->run(['command' => 'version', '--debug' => TRUE]);
     $this->assertEquals(OutputInterface::VERBOSITY_DEBUG, $tester->getOutput()->getVerbosity());
   }


### PR DESCRIPTION
### What's done

- Use ✔ and ✖ to indicate status
- Support `--quiet` and `-q` for quiet mode