### PR TITLE
Stop all exec commands with 'drall stop'

### DIFF
--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -56,6 +56,19 @@ abstract class BaseCommand extends Command {
     parent::initialize($input, $output);
   }
 
+  /**
+   * Formats a DateTime object for display in logs and messages.
+   *
+   * @param \DateTime $dateTime
+   *   The DateTime object to format.
+   *
+   * @return string
+   *   A human-readable date string, e.g. "4 Mar, 2026 @ 14:30:00".
+   */
+  public static function formatDateTime(\DateTime $dateTime): string {
+    return $dateTime->format('j M, Y @ H:i:s');
+  }
+
   protected function preExecute(InputInterface $input, OutputInterface $output) {
     if (!$this->hasSiteDetector()) {
       $this->setSiteDetector(new SiteDetector());

--- a/src/Command/StopCommand.php
+++ b/src/Command/StopCommand.php
@@ -43,7 +43,7 @@ final class StopCommand extends BaseCommand {
     /** @var \Symfony\Component\Console\Output\ConsoleOutput $output */
     $this->preExecute($input, $output);
 
-    $this->createStopFile();
+    $this->stop();
     return Command::SUCCESS;
   }
 

--- a/src/Trait/StoppableCommandTrait.php
+++ b/src/Trait/StoppableCommandTrait.php
@@ -53,6 +53,7 @@ trait StoppableCommandTrait {
    *   True or False.
    */
   private function isStopped(): bool {
+    // In case we already know that a stop was requested.
     if ($this->isStopped) {
       return $this->isStopped;
     }
@@ -61,30 +62,27 @@ trait StoppableCommandTrait {
       return FALSE;
     }
 
-    // @todo Only stop commands that started before the "stop" file was created.
-    $this->logger->warning('A drall.stop file was detected. Stopping.');
-    $this->deleteStopFile();
+    // Stop commands that started before the "stop" was made.
+    $stopTimestamp = file_get_contents($this->getStopFilePath());
+    if ($_SERVER['REQUEST_TIME'] >= $stopTimestamp) {
+      return FALSE;
+    }
+
+    $this->logger->warning("A stop was requested using '{command}'.", ['command' => 'drall stop']);
     return $this->isStopped = TRUE;
   }
 
   /**
-   * Create a drall.stop file.
+   * Request the command to stop using the drall.stop file.
    */
-  protected function createStopFile(): void {
-    if (!touch($this->getStopFilePath())) {
-      throw new \RuntimeException("Failed to touch: {$this->getStopFilePath()}");
+  protected function stop(): void {
+    $now = new \DateTime();
+    if (FALSE === file_put_contents($this->getStopFilePath(), $now->getTimestamp())) {
+      throw new \RuntimeException("Failed to write: {$this->getStopFilePath()}");
     }
 
-    $this->logger->notice("Created file: {file}", ['file' => $this->getStopFilePath()]);
-  }
-
-  /**
-   * Delete the drall.stop file, if exists.
-   */
-  protected function deleteStopFile(): void {
-    if (!unlink($this->getStopFilePath())) {
-      throw new \RuntimeException("Failed to unlink: {$this->getStopFilePath()}");
-    }
+    $this->logger->notice("A stop was requested at {datetime}.", ['datetime' => $this->formatDateTime($now)]);
+    $this->logger->debug("Touched file: {file}", ['file' => $this->getStopFilePath()]);
   }
 
 }

--- a/test/Integration/Command/StopCommandTest.php
+++ b/test/Integration/Command/StopCommandTest.php
@@ -12,44 +12,93 @@ use Symfony\Component\Process\Process;
 class StopCommandTest extends TestCase {
 
   /**
-   * @testdox Stops exec command.
+   * @testdox Stops all exec commands that started before "stop" was triggered.
    */
   public function testStop(): void {
-    // Start a long-running exec command.
+    // Start a long-running exec command 1.
     $process1 = Process::fromShellCommandline(
       'drall exec --no-progress --interval=2 -- ./vendor/bin/drush st --field=site 2>&1',
       static::PATH_DRUPAL,
     );
     $process1->start();
 
+    // Start long-running exec command 2.
+    $process2 = Process::fromShellCommandline(
+      'drall exec --no-progress --interval=2 -- ./vendor/bin/drush st --field=site 2>&1',
+      static::PATH_DRUPAL,
+    );
+    $process2->start();
+
     // Wait till the first two sites are processed.
     sleep(4);
 
     // Run the stop command.
-    $process2 = Process::fromShellCommandline(
-      'drall stop -v 2>&1',
+    $stopProcess = Process::fromShellCommandline(
+      'drall stop -d 2>&1',
       static::PATH_DRUPAL,
     );
-    $process2->run();
+    $stopProcess->run();
 
-    // Wait for process1 to finish.
+    // Wait for all processes to finish.
     $process1->wait();
+    $process2->wait();
 
-    // Assert that the first process detected the stop file.
+    // Start long-running exec command 3.
+    // This command is run after "stop" so it should finish successfully.
+    $process3 = Process::fromShellCommandline(
+      'drall exec --no-progress --interval=2 -- ./vendor/bin/drush st --field=site 2>&1',
+      static::PATH_DRUPAL,
+    );
+    $process3->run();
+
+    // Read the stop date and time.
+    $stopFilePath = sys_get_temp_dir() . '/drall.stop';
+    $this->assertFileExists($stopFilePath);
+    $dtStop = new \DateTime('@' . trim(file_get_contents($stopFilePath)));
+
+    // If PCNTL is available, a warning must be displayed.
+    $this->assertOutputEquals(<<<EOF
+[warning] It is discommended to use the "stop" command when PCNTL is available.
+[notice] A stop was requested at {$dtStop->format('j M, Y @ H:i:s')}.
+[debug] Touched file: /tmp/drall.stop
+
+EOF, $stopProcess->getOutput());
+
+    // Process 1 should detect the stop command.
     $this->assertOutputEquals(<<<EOF
 sites/default
 ✔ default: Done
 sites/donnie
 ✔ donnie: Done
-[warning] A drall.stop file was detected. Stopping.
+[warning] A stop was requested using 'drall stop'.
 
-EOF, $process1->getOutput());
+EOF, $process1->getOutput(), 'Process 1 did not respect the "stop" command.');
 
+    // Process 2 should detect the stop command.
     $this->assertOutputEquals(<<<EOF
-[warning] It is discommended to use the "stop" command when PCNTL is available.
-[notice] Created file: /tmp/drall.stop
+sites/default
+✔ default: Done
+sites/donnie
+✔ donnie: Done
+[warning] A stop was requested using 'drall stop'.
 
-EOF, $process2->getOutput());
+EOF, $process2->getOutput(), 'Process 2 did not respect the "stop" command.');
+
+    // Assert that the process 3 finished normally because the "stop" command
+    // was executed before process 3 started.
+    $this->assertOutputEquals(<<<EOF
+sites/default
+✔ default: Done
+sites/donnie
+✔ donnie: Done
+sites/leo
+✔ leo: Done
+sites/mikey
+✔ mikey: Done
+sites/ralph
+✔ ralph: Done
+
+EOF, $process3->getOutput(), 'Process 3 did not finish successfully.');
   }
 
 }


### PR DESCRIPTION
When 'drall stop' is executed, all commands that were running at the time of executing the 'stop' command can now detect the stop request and stop execution.