### PR TITLE
Obtain lock on --batch-file when writing; refs #87

### DIFF
--- a/src/Batch/FileBatch.php
+++ b/src/Batch/FileBatch.php
@@ -4,15 +4,62 @@ namespace Drall\Batch;
 
 final class FileBatch extends BatchBase {
 
+  /**
+   * File handle for the lock file.
+   *
+   * @var resource|null
+   */
+  private $lockHandle = NULL;
+
+  /**
+   * Opens a file-based batch.
+   *
+   * If the file exists and contains valid batch data, it is loaded.
+   * Otherwise, a fresh batch is initialized.
+   *
+   * @param string $path
+   *   Path to the batch JSON file.
+   * @param bool $writable
+   *   Whether the batch should be writable. Writable mode acquires an
+   *   exclusive file lock to prevent concurrent writes. Defaults to FALSE.
+   *
+   * @throws \RuntimeException
+   *   If writable mode is requested but the lock cannot be acquired.
+   */
   public function __construct(
     private readonly string $path,
+    bool $writable = FALSE,
   ) {
+    if ($writable) {
+      $this->acquireLock();
+    }
+
     if (!$this->load()) {
       $this->reset();
     }
   }
 
-  public function load(): bool {
+  /**
+   * Releases the file lock on destruction.
+   */
+  public function __destruct() {
+    $this->releaseLock();
+  }
+
+  /**
+   * Whether the batch was opened in writable mode.
+   */
+  public function isWritable(): bool {
+    return $this->lockHandle !== NULL;
+  }
+
+  /**
+   * Loads batch data from the file.
+   *
+   * @return bool
+   *   TRUE if the file was loaded successfully, FALSE otherwise.
+   */
+  private function load(): bool {
     if (!is_file($this->path)) {
       return FALSE;
     }
@@ -43,10 +90,61 @@ final class FileBatch extends BatchBase {
     return TRUE;
   }
 
+  /**
+   * {@inheritdoc}
+   *
+   * @throws \LogicException
+   *   If the batch was opened in readonly mode.
+   * @throws \RuntimeException
+   *   If the file cannot be written.
+   */
   protected function save(): void {
+    if (!$this->isWritable()) {
+      throw new \LogicException("Cannot write to a readonly batch file: $this->path");
+    }
+
     $this->data['updatedAt'] = new \DateTimeImmutable();
     if (FALSE === file_put_contents($this->path, json_encode($this->toArray(), JSON_PRETTY_PRINT))) {
       throw new \RuntimeException("Could not write file: $this->path");
+    }
+  }
+
+  /**
+   * Acquires an exclusive lock on the batch file.
+   *
+   * @throws \RuntimeException
+   *   If the lock file cannot be created or the lock cannot be acquired.
+   */
+  private function acquireLock(): void {
+    $lockPath = $this->path . '.lock';
+    $handle = @fopen($lockPath, 'c');
+    if ($handle === FALSE) {
+      throw new \RuntimeException("Could not create lock file: $lockPath");
+    }
+
+    if (!flock($handle, LOCK_EX | LOCK_NB)) {
+      fclose($handle);
+      throw new \RuntimeException("Could not acquire lock: $lockPath. Is another Drall instance running?");
+    }
+
+    $this->lockHandle = $handle;
+  }
+
+  /**
+   * Releases the exclusive lock and removes the lock file.
+   */
+  private function releaseLock(): void {
+    if ($this->lockHandle === NULL) {
+      return;
+    }
+
+    flock($this->lockHandle, LOCK_UN);
+    fclose($this->lockHandle);
+    $this->lockHandle = NULL;
+
+    $lockPath = $this->path . '.lock';
+    if (is_file($lockPath)) {
+      @unlink($lockPath);
     }
   }
 

--- a/src/Command/ExecCommand.php
+++ b/src/Command/ExecCommand.php
@@ -370,7 +370,7 @@ EOT);
       return $batch;
     }
 
-    $batch = new FileBatch($batchFile);
+    $batch = new FileBatch($batchFile, writable: TRUE);
 
     // No existing batch data — start fresh.
     if (!$batch->getItems()) {

--- a/test/Unit/Batch/FileBatchTest.php
+++ b/test/Unit/Batch/FileBatchTest.php
@@ -11,16 +11,57 @@ use Drall\TestCase;
  */
 class FileBatchTest extends TestCase {
 
-  public function test_creates_fresh_batch_when_file_does_not_exist() {
+  public function test_default_mode_is_readonly() {
     $path = static::createTempFilePath();
     $batch = new FileBatch($path);
+    $this->assertFalse($batch->isWritable());
+  }
+
+  public function test_writable_mode_acquires_lock() {
+    $path = static::createTempFilePath();
+    $batch = new FileBatch($path, writable: TRUE);
+    $this->assertTrue($batch->isWritable());
+    $this->assertFileExists($path . '.lock');
+  }
+
+  public function test_lock_prevents_second_writable_instance() {
+    $path = static::createTempFilePath();
+    $batch1 = new FileBatch($path, writable: TRUE);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Could not acquire lock');
+    $batch2 = new FileBatch($path, writable: TRUE);
+  }
+
+  public function test_lock_released_on_destruct() {
+    $path = static::createTempFilePath();
+    $batch = new FileBatch($path, writable: TRUE);
+    unset($batch);
+
+    // A second writable instance should now succeed.
+    $batch2 = new FileBatch($path, writable: TRUE);
+    $this->assertTrue($batch2->isWritable());
+  }
+
+  public function test_readonly_batch_throws_on_save() {
+    $path = static::createTempFilePath();
+    $batch = new FileBatch($path);
+
+    $this->expectException(\LogicException::class);
+    $this->expectExceptionMessage('Cannot write to a readonly batch file');
+    $batch->addItems(['site1']);
+  }
+
+  public function test_creates_fresh_batch_when_file_does_not_exist() {
+    $path = static::createTempFilePath();
+    $batch = new FileBatch($path, writable: TRUE);
     $this->assertEmpty($batch->getItems());
     $this->assertTrue($batch->isComplete());
   }
 
   public function test_save_creates_file() {
     $path = static::createTempFilePath();
-    $batch = new FileBatch($path);
+    $batch = new FileBatch($path, writable: TRUE);
     $batch->addItems(['site1']);
     $this->assertFileExists($path);
   }
@@ -29,14 +70,15 @@ class FileBatchTest extends TestCase {
     $path = static::createTempFilePath();
 
     // Create a batch and add items.
-    $batch = new FileBatch($path);
+    $batch = new FileBatch($path, writable: TRUE);
     $batch->addItems(['site1', 'site2', 'site3']);
     $items = $batch->getQueuedItems();
     $batch->startItem($items['site1']);
     $batch->finishItem($items['site1']);
     $batch->startItem($items['site2']);
+    unset($batch);
 
-    // Load from the same file.
+    // Load from the same file (readonly is sufficient for reading).
     $restored = new FileBatch($path);
     $this->assertCount(3, $restored->getItems());
     $this->assertCount(1, $restored->getQueuedItems());
@@ -48,12 +90,13 @@ class FileBatchTest extends TestCase {
   public function test_load_preserves_item_statuses() {
     $path = static::createTempFilePath();
 
-    $batch = new FileBatch($path);
+    $batch = new FileBatch($path, writable: TRUE);
     $batch->addItems(['site1', 'site2', 'site3']);
     $items = $batch->getQueuedItems();
     $batch->startItem($items['site1']);
     $batch->finishItem($items['site1']);
     $batch->startItem($items['site2']);
+    unset($batch);
 
     $restored = new FileBatch($path);
     $allItems = $restored->getItems();
@@ -62,14 +105,14 @@ class FileBatchTest extends TestCase {
     $this->assertEquals(BatchItemStatus::Queued, $allItems['site3']->getStatus());
   }
 
-  public function test_load_returns_false_for_missing_file() {
+  public function test_missing_file_creates_fresh_batch() {
     $path = static::createTempFilePath();
     unlink($path);
     $batch = new FileBatch($path);
-    $this->assertFalse($batch->load());
+    $this->assertEmpty($batch->getItems());
   }
 
-  public function test_load_returns_false_for_invalid_version() {
+  public function test_invalid_version_creates_fresh_batch() {
     $path = static::createTempFile(json_encode([
       'version' => '0.0',
       'startedAt' => '2026-01-01T00:00:00+00:00',
@@ -78,22 +121,21 @@ class FileBatchTest extends TestCase {
       'queued' => [],
       'finished' => [],
     ]));
-    $batch = new FileBatch($path);
+    $batch = new FileBatch($path, writable: TRUE);
     // The batch should have reset since the version is invalid.
     $this->assertEmpty($batch->getItems());
   }
 
-  public function test_load_returns_false_for_invalid_json() {
+  public function test_invalid_json_creates_fresh_batch() {
     $path = static::createTempFile('Invalid JSON');
     $batch = new FileBatch($path);
-    $this->assertFalse($batch->load());
     $this->assertEmpty($batch->getItems());
   }
 
   public function test_reset_clears_persisted_state() {
     $path = static::createTempFilePath();
 
-    $batch = new FileBatch($path);
+    $batch = new FileBatch($path, writable: TRUE);
     $batch->addItems(['site1', 'site2']);
     $items = $batch->getQueuedItems();
     $batch->startItem($items['site1']);
@@ -107,11 +149,12 @@ class FileBatchTest extends TestCase {
   public function test_get_finished_percentage_persists() {
     $path = static::createTempFilePath();
 
-    $batch = new FileBatch($path);
+    $batch = new FileBatch($path, writable: TRUE);
     $batch->addItems(['site1', 'site2']);
     $items = $batch->getQueuedItems();
     $batch->startItem($items['site1']);
     $batch->finishItem($items['site1']);
+    unset($batch);
 
     $restored = new FileBatch($path);
     $this->assertEquals('50.00', $restored->getFinishedPercentage());
@@ -120,9 +163,10 @@ class FileBatchTest extends TestCase {
   public function test_started_at_persists() {
     $path = static::createTempFilePath();
 
-    $batch = new FileBatch($path);
+    $batch = new FileBatch($path, writable: TRUE);
     $startedAt = $batch->getStartedAt();
     $batch->addItems(['site1']);
+    unset($batch);
 
     $restored = new FileBatch($path);
     $this->assertEquals(
@@ -133,17 +177,17 @@ class FileBatchTest extends TestCase {
 
   public function test_save_throws_exception_for_unwritable_path() {
     $path = '/dev/null/impossible';
-    $batch = new FileBatch($path);
 
     $this->expectException(\RuntimeException::class);
-    $this->expectExceptionMessage("Could not write file: $path");
+    $this->expectExceptionMessage("Could not create lock file");
+    $batch = new FileBatch($path, writable: TRUE);
     @$batch->addItems(['site1']);
   }
 
   public function test_updated_at_changes_on_save() {
     $path = static::createTempFilePath();
 
-    $batch = new FileBatch($path);
+    $batch = new FileBatch($path, writable: TRUE);
     $batch->addItems(['site1']);
     $updatedAt1 = $batch->getUpdatedAt();
 
@@ -152,6 +196,19 @@ class FileBatchTest extends TestCase {
     $updatedAt2 = $batch->getUpdatedAt();
 
     $this->assertGreaterThanOrEqual($updatedAt1, $updatedAt2);
+  }
+
+  public function test_multiple_readonly_instances_allowed() {
+    $path = static::createTempFilePath();
+
+    $batch = new FileBatch($path, writable: TRUE);
+    $batch->addItems(['site1', 'site2']);
+    unset($batch);
+
+    $reader1 = new FileBatch($path);
+    $reader2 = new FileBatch($path);
+    $this->assertCount(2, $reader1->getItems());
+    $this->assertCount(2, $reader2->getItems());
   }
 
 }


### PR DESCRIPTION
Prevents multiple Drall commands from colliding.